### PR TITLE
ci: run script to test bpftool types/options sync

### DIFF
--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -386,6 +386,15 @@ LIBBPF_PATH="${REPO_ROOT}" \
 	REPO_PATH="${REPO_PATH}" \
 	VMLINUX_BTF=${vmlinux} ${VMTEST_ROOT}/build_selftests.sh
 
+travis_fold start bpftool_checks "Running bpftool checks..."
+if [[ "${KERNEL}" = 'LATEST' ]]; then
+	"${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && \
+		echo "Consistency checks passed successfully."
+else
+	echo "Consistency checks skipped."
+fi
+travis_fold end bpftool_checks
+
 travis_fold start vm_init "Starting virtual machine..."
 
 if (( SKIPSOURCE )); then


### PR DESCRIPTION
This is a port from https://github.com/libbpf/libbpf/pull/352.

> When new eBPF program, map, or attach types are added to the kernel, bpftool needs to be updated in order to support the related features. These updates should add the new types to the code itself, but also to the help messages, documentation, and bash completion. Given that it is easy to omit one of those, a script has been created to attempt to validate that all parts have been consistently updated.
> 
> This new script for bpftool is hosted in the kernel repository, amongst the BPF selftests. But it is not called from the Makefile, and not run along with the other selftests. If it was, all patches updating the BPF UAPI would require the relevant changes in bpftool at the same time, _in the same patches_, which is not desirable.
> 
> To ensure that bpftool's parts remain in sync, let's run this script from the CI. This patch adds a new section to the run.sh script, focused on bpftool, and calling the new test_bpftool_synctypes.py.
