### PR TITLE
ci: install systemtap-sdt-devel package needed for USDT selftests

### DIFF
--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -17,7 +17,7 @@ runs:
       run: |
         echo "::group::Setup"
         sudo apt-get update
-        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
+        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils systemtap-sdt-devel
         echo "::endgroup::"
     - name: Install clang
       shell: bash


### PR DESCRIPTION
BPF selftests depend on sys/sdt.h header for defining USDT probes. This
header is coming from systemtap-sdt-devel package, so ensure this
package is installed before selftests are built.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>