### PR TITLE
Update INDEX to reference the latest rootfs image.

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -1,4 +1,4 @@
-x86_64/libbpf-vmtest-rootfs-2020.09.27.tar.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.09.27.tar.zst
+x86_64/libbpf-vmtest-rootfs-2022.04.25.tar.zst https://libbpf-ci.s3.us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2022.04.25.tar.zst
 x86_64/vmlinux-4.9.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-4.9.0.zst
 x86_64/vmlinux-5.5.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst
 x86_64/vmlinuz-5.5.0	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0


### PR DESCRIPTION
`ethtool` was added to the image. See https://github.com/libbpf/libbpf/pull/488

This change update INDEX file to point to the new image.

```
wget https://libbpf-ci.s3.us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2022.04.25.tar.zst
wget https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0

rootfs_img=rootfs.img kernel_bzimage=vmlinuz-5.5.0

mkdir rootfs
touch rootfs.img
truncate -s 2G rootfs.img
mkfs.ext4 -q rootfs.img
sudo mount -o loop rootfs.img rootfs
cat ./libbpf-vmtest-rootfs-2022.04.25.tar.zst | sudo tar -C rootfs -I zstd -xvf -
sudo umount rootfs
sudo install  -m 755 -o root -g root  /dev/stdin rootfs/etc/rcS.d/S50-startup <<'EOF'
ethtool -h
cat /etc/issue
EOF

qemu-system-x86_64 -nodefaults  -display none -serial mon:stdio -enable-kvm -m 4G -drive file="${rootfs_img}",format=raw,index=1,media=disk,if=virtio,cache=none -kernel "${kernel_bzimage}" -append "root=/dev/vda rw console=ttyS0,115200"
```