### PR TITLE
update INDEX to pick up new s390x image from libbpf/libbpf#492

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -3,4 +3,4 @@ x86_64/vmlinux-4.9.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vml
 x86_64/vmlinux-5.5.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst
 x86_64/vmlinuz-5.5.0	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0
 x86_64/vmlinuz-4.9.0	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-4.9.0
-s390x/libbpf-vmtest-rootfs-2021.03.24.tar.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/s390x/libbpf-vmtest-rootfs-2021.03.24.tar.zst
+s390x/libbpf-vmtest-rootfs-2022.05.09.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/s390x/libbpf-vmtest-rootfs-2022.05.09.tar.zst


### PR DESCRIPTION
update s390x image from https://github.com/libbpf/libbpf/pull/492

Test: Made sure I did not screw up tabs....

```
cat INDEX| awk -F '\t' '{print $1"**"$2}'
x86_64/libbpf-vmtest-rootfs-2020.09.27.tar.zst**https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.09.27.tar.zst
x86_64/vmlinux-4.9.0.zst**https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-4.9.0.zst
x86_64/vmlinux-5.5.0.zst**https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst
x86_64/vmlinuz-5.5.0**https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0
x86_64/vmlinuz-4.9.0**https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-4.9.0
s390x/libbpf-vmtest-rootfs-2022.05.09.tar.zst**https://libbpf-ci.s3.us-west-1.amazonaws.com/s390x/libbpf-vmtest-rootfs-2022.05.09.tar.zst
```