### PR TITLE
Remove DDWARVES_MINOR_VERSION workaround

### DIFF
--- a/setup-build-env/build_pahole.sh
+++ b/setup-build-env/build_pahole.sh
@@ -18,9 +18,6 @@ git remote add origin ${PAHOLE_ORIGIN}
 git fetch --depth=1 origin
 git checkout master
 
-# temporary fix up for pahole until official 1.22 release
-sed -i 's/DDWARVES_MINOR_VERSION=21/DDWARVES_MINOR_VERSION=22/' CMakeLists.txt
-
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -D__LIB=lib ..


### PR DESCRIPTION
Pahole 1.23 has been released. Looking at the git repository,
CMakeLists.txt already contains DDWARVES_MINOR_VERSION=23. Hence, the
temporary fix we have in place that updates minor version is no longer
necessary or having any effect. Remove it.