### PR TITLE
Add action for building samples/bpf

### DIFF
--- a/build-samples/action.yml
+++ b/build-samples/action.yml
@@ -1,0 +1,18 @@
+name: 'build samples/bpf'
+description: 'Build samples/bpf'
+inputs:
+  vmlinux_btf:
+    description: 'path to vmlinux BTF file'
+    required: true
+  kernel:
+    description: 'kernel version'
+    default: 'LATEST'
+  toolchain:
+    description: 'what toolchain to use'
+    default: 'gcc'
+runs:
+  using: "composite"
+  steps:
+    - name: build samples/bpf
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/build_samples.sh "${{ inputs.vmlinux_btf }}" "${{ inputs.kernel }}" "${{ inputs.toolchain }}"

--- a/build-samples/build_samples.sh
+++ b/build-samples/build_samples.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+THISDIR="$(cd $(dirname $0) && pwd)"
+
+source "${THISDIR}"/../helpers.sh
+
+VMLINUX_BTF="$1"
+KERNEL="$2"
+TOOLCHAIN="$3"
+TOOLCHAIN_NAME="$(echo $TOOLCHAIN | cut -d '-' -f 1)"
+TOOLCHAIN_VERSION="$(echo $TOOLCHAIN | cut -d '-' -f 2)"
+
+if [ "$TOOLCHAIN_NAME" == "llvm" ]; then
+export LLVM="-$TOOLCHAIN_VERSION"
+LLVM_VER=$TOOLCHAIN_VERSION
+else
+LLVM_VER=15
+fi
+
+foldable start build_samples "Building samples with $TOOLCHAIN"
+
+if [[ "${KERNEL}" = 'LATEST' ]]; then
+	VMLINUX_H=
+else
+	VMLINUX_H=${THISDIR}/vmlinux.h
+fi
+
+make headers_install
+make \
+	CLANG=clang-${LLVM_VER} \
+	OPT=opt-${LLVM_VER} \
+	LLC=llc-${LLVM_VER} \
+	LLVM_DIS=llvm-dis-${LLVM_VER} \
+	LLVM_OBJCOPY=llvm-objcopy-${LLVM_VER} \
+	LLVM_READELF=llvm-readelf-${LLVM_VER} \
+	LLVM_STRIP=llvm-strip-${LLVM_VER} \
+	VMLINUX_BTF="${VMLINUX_BTF}" \
+	VMLINUX_H="${VMLINUX_H}" \
+	-C "${REPO_ROOT}/${REPO_PATH}/samples/bpf" \
+	-j $((4*$(nproc)))
+
+foldable end build_samples


### PR DESCRIPTION
We have a bunch of BPF sample code that depends on core Linux and BPF
APIs. These APIs may change over time, but given that these samples are
not included in the 'all' target but have to be built separately, they
are more likely to go stale [0].
To at least ensure a minimum level of up-to-dateness, let's build these
samples as part of the CI. This change introduces an action that we can
use to perform such a build.

[0] https://lore.kernel.org/bpf/BN6PR11MB16331BEF1C7F6F37F76C55DD92899@BN6PR11MB1633.namprd11.prod.outlook.com/T/#mad6fae31be210e5231d63ebffcad305b9a0c7bae

Signed-off-by: Daniel Müller <deso@posteo.net>