### PR TITLE
Topic/more actions pr

### DIFF
--- a/build-linux/action.yml
+++ b/build-linux/action.yml
@@ -1,0 +1,15 @@
+name: 'build linux'
+description: 'Build Linux'
+inputs:
+  arch:
+    description: 'arch'
+    required: true
+  toolchain:
+    description: 'what toolchain to use'
+    default: 'gcc'
+runs:
+  using: "composite"
+  steps:
+    - name: build linux
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/build.sh "${{ inputs.arch }}" "${{ inputs.toolchain }}"

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ARCH="$1"
+TOOLCHAIN="$2"
+TOOLCHAIN_NAME="$(echo $TOOLCHAIN | cut -d '-' -f 1)"
+TOOLCHAIN_VERSION="$(echo $TOOLCHAIN | cut -d '-' -f 2)"
+
+if [ "$TOOLCHAIN_NAME" == "llvm" ]; then
+export LLVM="-$TOOLCHAIN_VERSION"
+fi
+
+THISDIR="$(cd $(dirname $0) && pwd)"
+
+source "${THISDIR}"/../helpers.sh
+
+foldable start build_kernel "Building kernel with $TOOLCHAIN"
+
+cp ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config-latest.${ARCH} .config
+
+make -j $((4*$(nproc))) olddefconfig all
+
+foldable end build_kernel

--- a/build-samples/action.yml
+++ b/build-samples/action.yml
@@ -1,0 +1,18 @@
+name: 'build samples/bpf'
+description: 'Build samples/bpf'
+inputs:
+  vmlinux_btf:
+    description: 'path to vmlinux BTF file'
+    required: true
+  kernel:
+    description: 'kernel version'
+    default: 'LATEST'
+  toolchain:
+    description: 'what toolchain to use'
+    default: 'gcc'
+runs:
+  using: "composite"
+  steps:
+    - name: build samples/bpf
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/build_samples.sh "${{ inputs.vmlinux_btf }}" "${{ inputs.kernel }}" "${{ inputs.toolchain }}"

--- a/build-samples/build_samples.sh
+++ b/build-samples/build_samples.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+THISDIR="$(cd $(dirname $0) && pwd)"
+
+source "${THISDIR}"/../helpers.sh
+
+VMLINUX_BTF="$1"
+KERNEL="$2"
+TOOLCHAIN="$3"
+TOOLCHAIN_NAME="$(echo $TOOLCHAIN | cut -d '-' -f 1)"
+TOOLCHAIN_VERSION="$(echo $TOOLCHAIN | cut -d '-' -f 2)"
+
+if [ "$TOOLCHAIN_NAME" == "llvm" ]; then
+export LLVM="-$TOOLCHAIN_VERSION"
+LLVM_VER=$TOOLCHAIN_VERSION
+else
+LLVM_VER=15
+fi
+
+foldable start build_samples "Building samples with $TOOLCHAIN"
+
+if [[ "${KERNEL}" = 'LATEST' ]]; then
+	VMLINUX_H=
+else
+	VMLINUX_H=${THISDIR}/vmlinux.h
+fi
+
+make headers_install
+make \
+	CLANG=clang-${LLVM_VER} \
+	OPT=opt-${LLVM_VER} \
+	LLC=llc-${LLVM_VER} \
+	LLVM_DIS=llvm-dis-${LLVM_VER} \
+	LLVM_OBJCOPY=llvm-objcopy-${LLVM_VER} \
+	LLVM_READELF=llvm-readelf-${LLVM_VER} \
+	LLVM_STRIP=llvm-strip-${LLVM_VER} \
+	VMLINUX_BTF="${VMLINUX_BTF}" \
+	VMLINUX_H="${VMLINUX_H}" \
+	-C "${REPO_ROOT}/${REPO_PATH}/samples/bpf" \
+	-j $((4*$(nproc)))
+
+foldable end build_samples

--- a/build-selftests/action.yml
+++ b/build-selftests/action.yml
@@ -1,0 +1,18 @@
+name: 'build selftests'
+description: 'Build BPF selftests'
+inputs:
+  vmlinux_btf:
+    description: 'path to vmlinux BTF file'
+    required: true
+  kernel:
+    description: 'kernel version'
+    default: 'LATEST'
+  toolchain:
+    description: 'what toolchain to use'
+    default: 'gcc'
+runs:
+  using: "composite"
+  steps:
+    - name: build selftests
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/build_selftests.sh "${{ inputs.vmlinux_btf }}" "${{ inputs.kernel }}" "${{ inputs.toolchain }}"

--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+THISDIR="$(cd $(dirname $0) && pwd)"
+
+source "${THISDIR}"/../helpers.sh
+
+VMLINUX_BTF="$1"
+KERNEL="$2"
+TOOLCHAIN="$3"
+TOOLCHAIN_NAME="$(echo $TOOLCHAIN | cut -d '-' -f 1)"
+TOOLCHAIN_VERSION="$(echo $TOOLCHAIN | cut -d '-' -f 2)"
+
+if [ "$TOOLCHAIN_NAME" == "llvm" ]; then
+export LLVM="-$TOOLCHAIN_VERSION"
+LLVM_VER=$TOOLCHAIN_VERSION
+else
+LLVM_VER=15
+fi
+
+foldable start build_selftests "Building selftests with $TOOLCHAIN"
+
+LIBBPF_PATH="${REPO_ROOT}"
+
+PREPARE_SELFTESTS_SCRIPT=${THISDIR}/prepare_selftests-${KERNEL}.sh
+if [ -f "${PREPARE_SELFTESTS_SCRIPT}" ]; then
+	(cd "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" && ${PREPARE_SELFTESTS_SCRIPT})
+fi
+
+if [[ "${KERNEL}" = 'LATEST' ]]; then
+	VMLINUX_H=
+else
+	VMLINUX_H=${THISDIR}/vmlinux.h
+fi
+
+cd ${REPO_ROOT}/${REPO_PATH}
+make \
+	CLANG=clang-${LLVM_VER} \
+	LLC=llc-${LLVM_VER} \
+	LLVM_STRIP=llvm-strip-${LLVM_VER} \
+	VMLINUX_BTF="${VMLINUX_BTF}" \
+	VMLINUX_H="${VMLINUX_H}" \
+	-C "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
+	-j $((4*$(nproc))) > /dev/null
+cd -
+mkdir "${LIBBPF_PATH}"/selftests
+cp -R "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
+  "${LIBBPF_PATH}"/selftests
+cd "${LIBBPF_PATH}"
+
+foldable end build_selftests


### PR DESCRIPTION
Instead of having a bunch of shell scripts here and a bunch more over in `kernel-patches/vmtest`, let's consolidate more here. Doing so will allow us to remove a bunch of duplicated scripts (such as `helpers.sh`, which I've counted to exist four times!).

This change adds actions that can be invoked by `vmtest` (or others), alongside the already existing ones performing similar tasks.