### PR TITLE
Factor out LLVM version parsing function

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -2,18 +2,17 @@
 
 set -euo pipefail
 
-ARCH="$1"
-TOOLCHAIN="$2"
-TOOLCHAIN_NAME="$(echo $TOOLCHAIN | cut -d '-' -f 1)"
-TOOLCHAIN_VERSION="$(echo $TOOLCHAIN | cut -d '-' -f 2)"
-
-if [ "$TOOLCHAIN_NAME" == "llvm" ]; then
-export LLVM="-$TOOLCHAIN_VERSION"
-fi
-
 THISDIR="$(cd $(dirname $0) && pwd)"
 
 source "${THISDIR}"/../helpers.sh
+
+ARCH="$1"
+TOOLCHAIN="$2"
+
+LLVM_VER="$(llvm_version $TOOLCHAIN)" && :
+if [ $? -eq 0 ]; then
+	export LLVM="-$LLVM_VER"
+fi
 
 foldable start build_kernel "Building kernel with $TOOLCHAIN"
 

--- a/build-samples/build_samples.sh
+++ b/build-samples/build_samples.sh
@@ -9,14 +9,10 @@ source "${THISDIR}"/../helpers.sh
 VMLINUX_BTF="$1"
 KERNEL="$2"
 TOOLCHAIN="$3"
-TOOLCHAIN_NAME="$(echo $TOOLCHAIN | cut -d '-' -f 1)"
-TOOLCHAIN_VERSION="$(echo $TOOLCHAIN | cut -d '-' -f 2)"
 
-if [ "$TOOLCHAIN_NAME" == "llvm" ]; then
-export LLVM="-$TOOLCHAIN_VERSION"
-LLVM_VER=$TOOLCHAIN_VERSION
-else
-LLVM_VER=15
+LLVM_VER="$(llvm_version $TOOLCHAIN)" && :
+if [ $? -eq 0 ]; then
+	export LLVM="-$LLVM_VER"
 fi
 
 foldable start build_samples "Building samples with $TOOLCHAIN"

--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -9,14 +9,10 @@ source "${THISDIR}"/../helpers.sh
 VMLINUX_BTF="$1"
 KERNEL="$2"
 TOOLCHAIN="$3"
-TOOLCHAIN_NAME="$(echo $TOOLCHAIN | cut -d '-' -f 1)"
-TOOLCHAIN_VERSION="$(echo $TOOLCHAIN | cut -d '-' -f 2)"
 
-if [ "$TOOLCHAIN_NAME" == "llvm" ]; then
-export LLVM="-$TOOLCHAIN_VERSION"
-LLVM_VER=$TOOLCHAIN_VERSION
-else
-LLVM_VER=15
+LLVM_VER="$(llvm_version $TOOLCHAIN)" && :
+if [ $? -eq 0 ]; then
+	export LLVM="-$LLVM_VER"
 fi
 
 foldable start build_selftests "Building selftests with $TOOLCHAIN"

--- a/helpers.sh
+++ b/helpers.sh
@@ -34,3 +34,18 @@ print_error() {
 print_notice() {
   __print notice $1 $2
 }
+
+# $1 - toolchain name
+llvm_version() {
+  local toolchain="$1"
+  local toolchain_name="$(echo $toolchain | cut -d '-' -f 1)"
+  local toolchain_version="$(echo $toolchain | cut -d '-' -f 2)"
+
+  if [ "$toolchain_name" == "llvm" ]; then
+    echo "$toolchain_version"
+    return 0
+  else
+    echo "15"
+    return 1
+  fi
+}


### PR DESCRIPTION
As discussed in an earlier [pull request][pr20] this change introduces a
function for the LLVM parsing logic and uses it to deduplicate the three
copies of it.

[pr20]: https://github.com/libbpf/ci/pull/20#discussion_r929369587

Signed-off-by: Daniel Müller <deso@posteo.net>