### PR TITLE
Rely on upstream kernel configuration

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -17,7 +17,8 @@ source "${THISDIR}"/../helpers.sh
 
 foldable start build_kernel "Building kernel with $TOOLCHAIN"
 
-cp ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config-latest.${ARCH} .config
+cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config > .config
+cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.${ARCH} >> .config
 
 make -j $((4*$(nproc))) olddefconfig all
 


### PR DESCRIPTION
So far we have relied on the kernel configuration as checked into the
kernel-patches/vmtest repository. However, this configuration is now
included in upstream Linux [0].
With this change we switch over to using the configuration from there.

[0] https://lore.kernel.org/bpf/165893461358.29339.11641967418379627671.git-patchwork-notify@kernel.org/T/#m2a97b0ea9ef0ddee7a53bbf7919e3f324b233937

Signed-off-by: Daniel Müller <deso@posteo.net>