### PR TITLE
Revert "Rely on upstream kernel configuration"

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -16,8 +16,7 @@ fi
 
 foldable start build_kernel "Building kernel with $TOOLCHAIN"
 
-cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config > .config
-cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.${ARCH} >> .config
+cp ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config-latest.${ARCH} .config
 
 make -j $((4*$(nproc))) olddefconfig all
 


### PR DESCRIPTION
This change reverts commit 92f123b240be8b5fbebd08c7e5e2460b87e67e09. The
remaining instability in CI (caused by a NULL pointer dereference in the
kernel itself; reported [here]) seems to be caused by changes made as
part of minimizing the kernel configuration.
Let's rely on the non-upstream kernel configuration for now and until we
know which options precisely we should add (and/or fix the bug in
question).

[here]: https://lore.kernel.org/bpf/d8184db7-3247-c75f-7797-d3a5b0488743@huawei.com/T/#m1ea0cf0140edbd60d173f3ad52732db19a48cf2c