### PR TITLE
Bump LLVM version we use to 16

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -45,7 +45,7 @@ llvm_version() {
     echo "$toolchain_version"
     return 0
   else
-    echo "15"
+    echo "16"
     return 1
   fi
 }

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -14,7 +14,7 @@ while [ $n -lt 5 ]; do
   set +e && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
   sudo apt-get update && \
-  sudo apt-get install -y clang-15 lld-15 llvm-15 && \
+  sudo apt-get install -y clang-16 lld-16 llvm-16 && \
   set -e && \
   break
   n=$(($n + 1))


### PR DESCRIPTION
Development on LLVM 16 has started and version 15 is no longer available
in the repository we install it from. Bump the version we use
accordingly.

Signed-off-by: Daniel Müller <deso@posteo.net>