### PR TITLE
Stop sourcing -latest kernel config

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -18,8 +18,6 @@ foldable start build_kernel "Building kernel with $TOOLCHAIN"
 
 cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config \
     ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.${ARCH} \
-    ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config-latest \
-    ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config-latest.${ARCH} \
     ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config \
     ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config.${ARCH} 2> /dev/null > .config && :
 


### PR DESCRIPTION
https://github.com/kernel-patches/vmtest/commit/e5a73f5867617c873268914c229edbf8d407bf48
has renamed the kernel configuration in the kernel-patches/vmtest
repository, removing the '-latest' suffix.
As such, there is no need for us to keep attempting to source this file.
Stop doing so.

Signed-off-by: Daniel Müller <deso@posteo.net>