### PR TITLE
Introduce get-llvm-version action

### DIFF
--- a/get-llvm-version/action.yml
+++ b/get-llvm-version/action.yml
@@ -1,0 +1,12 @@
+name: 'get-llvm-version'
+description: 'Retrieve the LLVM version to use'
+outputs:
+  version:
+    description: "LLVM version"
+    value: ${{ steps.llvm-version.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    - id: llvm-version
+      shell: bash
+      run: echo "::set-output name=version::$(source $GITHUB_ACTION_PATH/../helpers.sh; llvm_default_version)"

--- a/helpers.sh
+++ b/helpers.sh
@@ -35,6 +35,11 @@ print_notice() {
   __print notice $1 $2
 }
 
+# No arguments
+llvm_default_version() {
+  echo "16"
+}
+
 # $1 - toolchain name
 llvm_version() {
   local toolchain="$1"
@@ -45,7 +50,7 @@ llvm_version() {
     echo "$toolchain_version"
     return 0
   else
-    echo "16"
+    llvm_default_version
     return 1
   fi
 }

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -8,13 +8,15 @@ foldable start install_clang "Installing Clang/LLVM"
 sudo apt-get update
 sudo apt-get install -y g++ libelf-dev
 
+LLVM_VERSION=$(llvm_default_version)
+
 echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" | sudo tee -a /etc/apt/sources.list
 n=0
 while [ $n -lt 5 ]; do
   set +e && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
   sudo apt-get update && \
-  sudo apt-get install -y clang-16 lld-16 llvm-16 && \
+  sudo apt-get install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION} llvm-${LLVM_VERSION} && \
   set -e && \
   break
   n=$(($n + 1))


### PR DESCRIPTION
Whenever development on a new LLVM version starts, earlier versions of
llvm, clang, and lld may seize to exist in distribution snapshot
repositories. For us, that means having to manually bump the version in
three repositories [0][1][2], in a specific order. That's cumbersome to
do and ultimately we probably want a single source of truth as to what
the most recent LLVM version to use is.
This change introduces an action that centralizes this information while
making it available across repository boundaries. We will subsequently
be able to eliminate hardcoded version information in the other two
repositories constituting the BPF CI.

[0] https://github.com/kernel-patches/vmtest/pull/107
[1] https://github.com/libbpf/libbpf/pull/542
[2] https://github.com/libbpf/ci/pull/24