### PR TITLE
Preserve selftest build output

### DIFF
--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -38,7 +38,7 @@ make \
 	VMLINUX_BTF="${VMLINUX_BTF}" \
 	VMLINUX_H="${VMLINUX_H}" \
 	-C "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
-	-j $((4*$(nproc))) > /dev/null
+	-j $((4*$(nproc)))
 cd -
 mkdir "${LIBBPF_PATH}"/selftests
 cp -R "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \


### PR DESCRIPTION
The selftest build is currently redirected to /dev/null. That
potentially makes it hard to understand what is going on. Given that the
UI hides the output by default anyway, but allows for inspection if
necessary, because of the fold makers, let's just emit said output.

Signed-off-by: Daniel Müller <deso@posteo.net>