### PR TITLE
Change upstream kernel configuration to compile everything built-in

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -19,7 +19,8 @@ foldable start build_kernel "Building kernel with $TOOLCHAIN"
 cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config \
     ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.${ARCH} \
     ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config \
-    ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config.${ARCH} 2> /dev/null > .config && :
+    ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config.${ARCH} 2> /dev/null | \
+        sed 's/=m$/=y/g' > .config && :
 
 make -j $((4*$(nproc))) olddefconfig all
 


### PR DESCRIPTION
Change the upstream kernel configuration by replacing =m with =y, to force
the CI to build everything built-in, since kernel modules are not copied
to the virtual machine where selftests run.

Signed-off-by: Roberto Sassu <roberto.sassu@huawei.com>