### PR TITLE
Fix prepare-rootfs action when using separate jobs

### DIFF
--- a/prepare-rootfs/run_vmtest.sh
+++ b/prepare-rootfs/run_vmtest.sh
@@ -7,7 +7,8 @@ THISDIR="$(cd $(dirname $0) && pwd)"
 source "${THISDIR}"/../helpers.sh
 
 foldable start env "Setup env"
-sudo apt install -y libguestfs-tools
+sudo apt-get update
+sudo apt-get install -y libguestfs-tools zstd
 foldable stop env
 
 USER=`whoami`


### PR DESCRIPTION
With upcoming changes we will introduce more "stages" to the CI
pipeline: instead of having basically a single job (though executed in
different configurations), that does everything from installing
dependencies to building to running tests in one go, we'd like to make
building and running of tests (the two longest running parts of the
overall pipeline) separate (but dependent on each other).

Currently, however, at least on s390x runners, that would fail, because
tests are being run in a new container environment where side-effects of
setup steps done earlier are no longer present. Specifically, as part of
the build preparation we updated the apt repository information
and made sure to install the zstd package.

With this change we make sure to repeat both steps as part of the 'test'
stage (of which the `prepare-rootfs` action is part).

Signed-off-by: Daniel Müller <deso@posteo.net>