### PR TITLE
Make Qemu image path configurable

### DIFF
--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -1,6 +1,6 @@
 name: 'prepare-rootfs'
 description: 'build rootfs
-1. download base root img to /tmp/root.img
+1. download base root img to /tmp/root.img (or other path, if provided)
 2. either copy "/vmlinux" or download "vmlinux" to "/boot" in image
 3. (FIXME) either copy "/vmlinuz" from build dir or download "vmlinuz" to workspace root
 4. copy hardcoded "selftests" and "travis-ci/vmtest" directory to "/$PROJECT_NAME" in root image
@@ -21,6 +21,9 @@ inputs:
     description: 'kernel source dir'
     default: '.kernel'
     required: true
+  image-output:
+    description: 'path where to store the generated image'
+    default: '/tmp/root.img'
 runs:
   using: "composite"
   steps:
@@ -28,7 +31,7 @@ runs:
         export REPO_ROOT="${{ github.workspace }}"
         export KERNEL="${{ inputs.kernel }}"
         export KERNEL_ROOT="${{ inputs.kernel-root }}"
-        $GITHUB_ACTION_PATH/run_vmtest.sh
+        $GITHUB_ACTION_PATH/run_vmtest.sh ${{ inputs.image-output }}
       shell: bash
       env:
         PROJECT_NAME: ${{ inputs.project-name }}

--- a/prepare-rootfs/run_vmtest.sh
+++ b/prepare-rootfs/run_vmtest.sh
@@ -6,6 +6,8 @@ THISDIR="$(cd $(dirname $0) && pwd)"
 
 source "${THISDIR}"/../helpers.sh
 
+IMAGE="${1}"
+
 foldable start env "Setup env"
 sudo apt-get update
 sudo apt-get install -y libguestfs-tools zstd
@@ -23,7 +25,7 @@ VMTEST_SETUPCMD="export GITHUB_WORKFLOW=${GITHUB_WORKFLOW:-}; export PROJECT_NAM
 setup_cmd=$(sed 's/\([[:space:]]\)/\\\1/g' <<< "${VMTEST_SETUPCMD}")
 
 if [[ "${KERNEL}" = 'LATEST' ]]; then
-  "${THISDIR}"/run.sh -b "${KERNEL_ROOT}" -o -d ~ -s "${setup_cmd}" /tmp/root.img
+  "${THISDIR}"/run.sh -b "${KERNEL_ROOT}" -o -d ~ -s "${setup_cmd}" "${IMAGE}"
 else
-  "${THISDIR}"/run.sh -k "${KERNEL}*" -o -d ~ -s "${setup_cmd}" /tmp/root.img
+  "${THISDIR}"/run.sh -k "${KERNEL}*" -o -d ~ -s "${setup_cmd}" "${IMAGE}"
 fi


### PR DESCRIPTION
The path to the file system image used by our invocation of Qemu is
currently hard coded to /tmp/root.img. This constant originates in the
run_vmtest.sh script, but is then hard-coded in other locations as well,
without an obvious connection between the two. That makes it hard to
understand the code.
This change makes the path to the image an explicit input parameter to
the prepare-rootfs action and the run_vmtest.sh script, which will make
it possible to make the input-output relationship more obvious in client
code moving forward.

Signed-off-by: Daniel Müller <deso@posteo.net>