### PR TITLE
Plumb through test to run

### DIFF
--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -24,6 +24,10 @@ inputs:
   image-output:
     description: 'path where to store the generated image'
     default: '/tmp/root.img'
+  test:
+    description: 'the name of the test to run'
+    default: ''
+    required: false
 runs:
   using: "composite"
   steps:
@@ -31,7 +35,7 @@ runs:
         export REPO_ROOT="${{ github.workspace }}"
         export KERNEL="${{ inputs.kernel }}"
         export KERNEL_ROOT="${{ inputs.kernel-root }}"
-        $GITHUB_ACTION_PATH/run_vmtest.sh ${{ inputs.image-output }}
+        $GITHUB_ACTION_PATH/run_vmtest.sh ${{ inputs.image-output }} ${{ inputs.test }}
       shell: bash
       env:
         PROJECT_NAME: ${{ inputs.project-name }}

--- a/prepare-rootfs/run_vmtest.sh
+++ b/prepare-rootfs/run_vmtest.sh
@@ -7,6 +7,7 @@ THISDIR="$(cd $(dirname $0) && pwd)"
 source "${THISDIR}"/../helpers.sh
 
 IMAGE="${1}"
+TEST="${2:-}"
 
 foldable start env "Setup env"
 sudo apt-get update
@@ -20,7 +21,7 @@ if [[ ${USER} != 'root' ]]; then
   foldable stop adduser_to_kvm
 fi
 
-VMTEST_SETUPCMD="export GITHUB_WORKFLOW=${GITHUB_WORKFLOW:-}; export PROJECT_NAME=${PROJECT_NAME}; /${PROJECT_NAME}/vmtest/run_selftests.sh"
+VMTEST_SETUPCMD="export GITHUB_WORKFLOW=${GITHUB_WORKFLOW:-}; export PROJECT_NAME=${PROJECT_NAME}; /${PROJECT_NAME}/vmtest/run_selftests.sh ${TEST}"
 # Escape whitespace characters.
 setup_cmd=$(sed 's/\([[:space:]]\)/\\\1/g' <<< "${VMTEST_SETUPCMD}")
 


### PR DESCRIPTION
We would like to have the ability to run selftests in parallel as
opposed to fully serial as is currently the case. In order to make that
possible, this change adjusts the `prepare-rootfs` action to accept an
optional argument specifying the test to run and passes it to the
`run_selftests.sh` script that we adjusted already to earlier.

Signed-off-by: Daniel Müller <deso@posteo.net>