### PR TITLE
Remove default value for image-output argument

### DIFF
--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: true
   image-output:
     description: 'path where to store the generated image'
-    default: '/tmp/root.img'
+    required: true
   test:
     description: 'the name of the test to run'
     default: ''


### PR DESCRIPTION
With both vmtest [0] and libbpf [1] now providing the image-output
argument to the prepare-rootfs action, we no longer need it to have a
default value. Remove it and make the input required.

[0] https://github.com/kernel-patches/vmtest/commit/281b3c8bfdea9748783e18ec2eafa5736525b72f
[1] https://github.com/libbpf/libbpf/commit/69938da6d7748a7b445954a959288b15bf9d8c38

Signed-off-by: Daniel Müller <deso@posteo.net>