### PR TITLE
Remove default arguments from prepare-rootfs action

### DIFF
--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -14,12 +14,10 @@ inputs:
     description: 'arch'
     required: true
   kernel:
-    description: 'kernel version'
-    default: 'LATEST'
+    description: 'kernel version; use LATEST to use the most recent version'
     required: true
   kernel-root:
     description: 'kernel source dir'
-    default: '.kernel'
     required: true
   image-output:
     description: 'path where to store the generated image'


### PR DESCRIPTION
Having default arguments on an action should probably be avoided if
possible. For one, it's confusing to see something being "required" but
having a default value, but if not explicitly mentioned on the call
site, it's also unnecessarily hard to understand what is going on.

With https://github.com/libbpf/libbpf/pull/570 merged we no longer need
default values for two arguments to the prepare-rootfs action, as all
call sites explicitly provide values. Hence, remove them.

Signed-off-by: Daniel Müller <deso@posteo.net>