### PR TITLE
Uppercase vmlinuz variable

### DIFF
--- a/run-qemu/action.yml
+++ b/run-qemu/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: test
       shell: bash
       env:
-        vmlinuz: ${{ inputs.vmlinuz }}
+        VMLINUZ: ${{ inputs.vmlinuz }}
         IMG: ${{ inputs.img }}
       run: |
         ARCH="${{ inputs.arch }}" ${GITHUB_ACTION_PATH}/run.sh

--- a/run-qemu/run.sh
+++ b/run-qemu/run.sh
@@ -42,7 +42,7 @@ fi
   -serial chardev:char0 \
   ${accel} -smp "$smp" -m 6G \
   -drive file="$IMG",format=raw,index=1,media=disk,if=virtio,cache=none \
-  -kernel "$vmlinuz" -append "root=/dev/vda rw console=$console panic=-1 sysctl.vm.panic_on_oom=1 $APPEND"
+  -kernel "$VMLINUZ" -append "root=/dev/vda rw console=$console panic=-1 sysctl.vm.panic_on_oom=1 $APPEND"
 
 exitfile="$(cat $GITHUB_WORKSPACE/bpftool_exitstatus)\n"
 exitfile+="$(guestfish --ro -a "$IMG" -i cat /exitstatus 2>/dev/null)"


### PR DESCRIPTION
We typically used fully uppercased names for environment variables in
shell scripts. There does not seem to be a good reason for diverging for
$vmlinuz specifically. Rename it.

Signed-off-by: Daniel Müller <deso@posteo.net>