### PR TITLE
Add kernel-root argument to run-qemu action

### DIFF
--- a/run-qemu/action.yml
+++ b/run-qemu/action.yml
@@ -10,6 +10,9 @@ inputs:
   vmlinuz:
     description: 'vmlinuz path'
     required: true
+  kernel-root:
+    description: 'kernel source dir'
+    default: '.'
 runs:
   using: "composite"
   steps:
@@ -18,5 +21,6 @@ runs:
       env:
         vmlinuz: ${{ inputs.vmlinuz }}
         IMG: ${{ inputs.img }}
+        KERNEL_ROOT: ${{ inputs.kernel-root }}
       run: |
         ARCH="${{ inputs.arch }}" ${GITHUB_ACTION_PATH}/run.sh


### PR DESCRIPTION
This change adds the kernel-root argument to the run-qemu action. We
will need this argument once we want to move bpftool checks into the
actual selftest run job, as opposed to having them happen in the
unrelated prepare-rootfs. We need a default value while all "callers"
are being transitioned to providing this argument. The KERNEL_ROOT
variable that we set based on it is not currently unused (will come with
subsequent changes).

Signed-off-by: Daniel Müller <deso@posteo.net>