### PR TITLE
Move bpftool check into run-qemu action

### DIFF
--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -4,7 +4,6 @@ description: 'build rootfs
 2. either copy "/vmlinux" or download "vmlinux" to "/boot" in image
 3. (FIXME) either copy "/vmlinuz" from build dir or download "vmlinuz" to workspace root
 4. copy hardcoded "selftests" and "travis-ci/vmtest" directory to "/$PROJECT_NAME" in root image
-5. (FIXME) run bpftool check and save result in $GITHUB_WORKSPACE/bpftool_exitstatus
 '
 inputs:
   project-name:

--- a/prepare-rootfs/run.sh
+++ b/prepare-rootfs/run.sh
@@ -405,27 +405,6 @@ guestfish --remote \
 
 foldable end vmlinux_setup
 
-foldable start bpftool_checks "Running bpftool checks..."
-bpftool_exitstatus=
-if [[ "${KERNEL}" = 'LATEST' ]]; then
-	# "&& true" does not change the return code (it is not executed if the
-	# Python script fails), but it prevents the trap on ERR set at the top
-	# of this file to trigger on failure.
-	"${REPO_ROOT}/${KERNEL_ROOT}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && true
-	bpftool_exitstatus=$?
-	if [[ "$bpftool_exitstatus" -eq 0 ]]; then
-		echo "bpftool checks passed successfully."
-	else
-		echo "bpftool checks returned ${bpftool_exitstatus}."
-	fi
-	bpftool_exitstatus="bpftool:${bpftool_exitstatus}"
-else
-	echo "bpftool checks skipped."
-	bpftool_exitstatus="bpftool:0"
-fi
-echo ${bpftool_exitstatus} > $GITHUB_WORKSPACE/bpftool_exitstatus
-foldable end bpftool_checks
-
 foldable start copy_files "Copying files..."
 
 if (( SKIPSOURCE )); then


### PR DESCRIPTION
Currently the bpftool tests are run as part of the prepare-rootfs
action. That's counter-intuitive, as running a test has nothing
"preparational" to it. That in turn causes confusion with users that are
trying to debug failures of said tests: they have no idea how to find
the logs in question, because success/failure is reported as part of a
later action.
This change moves the running of the bpftool tests into the run-qemu
action, which is where selftest results are reported as well. As such,
we remove the need for an implicit file with a hard coded path being
used for communication between these two steps, and of course the
confusion for users is fixed as well.
It is still sub-optimal because we are running this test for every other
selftest run, but that is unchanged from before. The remaining issues
will be addressed at a later point.

Signed-off-by: Daniel Müller <deso@posteo.net>