### PR TITLE
Add switch case to be able to run arm64 images in qemu

### DIFF
--- a/run-qemu/run.sh
+++ b/run-qemu/run.sh
@@ -49,6 +49,14 @@ x86_64)
 	kvm_accel="-cpu kvm64 -enable-kvm"
 	tcg_accel="-cpu qemu64 -machine accel=tcg"
 	;;
+aarch64)
+	qemu="qemu-system-aarch64"
+	console="ttyAMA0,115200"
+	smp=$(nproc)
+	kvm_accel="-cpu host -enable-kvm -machine virt,gic-version=3,accel=kvm:tcg"
+	tcg_accel="-cpu cortex-a72 -machine virt,accel=tcg"
+	;;
+
 *)
 	echo "Unsupported architecture"
 	exit 1


### PR DESCRIPTION
The qemu parameters where tested as part of https://github.com/kernel-patches/rcu-rc/actions/runs/3193882128/jobs/5213462935

The `kvm_accel` values are very much a guess. This was only tested on AWS graviton host where kvm is not available.