### PR TITLE
Remove references to travis-ci/ directory

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -18,8 +18,8 @@ foldable start build_kernel "Building kernel with $TOOLCHAIN"
 
 cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config \
     ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.${ARCH} \
-    ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config \
-    ${GITHUB_WORKSPACE}/travis-ci/vmtest/configs/config.${ARCH} 2> /dev/null > .config && :
+    ${GITHUB_WORKSPACE}/ci/vmtest/configs/config \
+    ${GITHUB_WORKSPACE}/ci/vmtest/configs/config.${ARCH} 2> /dev/null > .config && :
 
 make -j $((4*$(nproc))) olddefconfig all
 

--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -3,7 +3,7 @@ description: 'build rootfs
 1. download base root img to /tmp/root.img (or other path, if provided)
 2. either copy "/vmlinux" or download "vmlinux" to "/boot" in image
 3. (FIXME) either copy "/vmlinuz" from build dir or download "vmlinuz" to workspace root
-4. copy hardcoded "selftests" and "travis-ci/vmtest" directory to "/$PROJECT_NAME" in root image
+4. copy hardcoded "selftests" and "ci/vmtest" directory to "/$PROJECT_NAME" in root image
 '
 inputs:
   project-name:

--- a/prepare-rootfs/run.sh
+++ b/prepare-rootfs/run.sh
@@ -421,10 +421,10 @@ else
 		guestfish --remote \
 			mkdir-p "/${PROJECT_NAME}/selftests" : \
 			chmod 0755 "/${PROJECT_NAME}/selftests" : \
-			mkdir-p "/${PROJECT_NAME}/travis-ci" : \
-			chmod 0755 "/${PROJECT_NAME}/travis-ci"
+			mkdir-p "/${PROJECT_NAME}/ci" : \
+			chmod 0755 "/${PROJECT_NAME}/ci"
 		tar -C "${REPO_ROOT}/selftests" -c bpf | tar_in "/${PROJECT_NAME}/selftests"
-		tar -C "${REPO_ROOT}/travis-ci" -c vmtest  | tar_in "/${PROJECT_NAME}"
+		tar -C "${REPO_ROOT}/ci" -c vmtest  | tar_in "/${PROJECT_NAME}"
 	fi
 fi
 


### PR DESCRIPTION
With
https://github.com/libbpf/libbpf/commit/bfdf7653e0c46127bb889a5f73eea803bea1d81a and
https://github.com/kernel-patches/vmtest/commit/1656bf12ea2a6b29f3ac5fe274699ef800ab98af we have adjusted both clients of this repository to store their CI related functionality in the ci/ directory, as opposed to travis-ci/. Thus, we can now adjust the references to the latter here as well, and subsequently remove the symbolic links introduced in both repositories as an intermediate solution preventing breakage.

Signed-off-by: Daniel Müller <deso@posteo.net>