### PR TITLE
ci: Install qemu tools before running qemu

### DIFF
--- a/run-qemu/action.yml
+++ b/run-qemu/action.yml
@@ -16,6 +16,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: install qemu tools
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm
     - name: test
       shell: bash
       env:


### PR DESCRIPTION
It seems that the tools are not available within the runner anymore:

https://github.com/kernel-patches/rcu-rc/actions/runs/3222971213/jobs/5272953366#step:5:30

https://gist.github.com/chantra/c456efce54e3477984fde89eb0c9c939#file-runner-log-L743

This change makes sure qemu for the different architectures we may support is installed.

After this change, run-qemu action was able to successfully start the VM.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>