### PR TITLE
ci: Update images for all architectures

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -1,7 +1,10 @@
 x86_64/libbpf-vmtest-rootfs-2022.04.25.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2022.04.25.tar.zst
+x86_64/libbpf-vmtest-rootfs-2022.10.10-amd64.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2022.10.10-amd64.tar.zst
 x86_64/vmlinux-4.9.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-4.9.0.zst
 x86_64/vmlinux-5.5.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst
 x86_64/vmlinuz-5.5.0	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0
 x86_64/vmlinuz-4.9.0	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-4.9.0
 s390x/libbpf-vmtest-rootfs-2022.05.09.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/s390x/libbpf-vmtest-rootfs-2022.05.09.tar.zst
+s390x/libbpf-vmtest-rootfs-2022.10.10-s390x.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/s390x/libbpf-vmtest-rootfs-2022.10.10-s390x.tar.zst
 aarch64/libbpf-vmtest-rootfs-2022.10.04.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/aarch64/libbpf-vmtest-rootfs-2022.10.04.tar.zst
+aarch64/libbpf-vmtest-rootfs-2022.10.10-arm64.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/aarch64/libbpf-vmtest-rootfs-2022.10.10-arm64.tar.zst


### PR DESCRIPTION
Those images are all debian based and have an updated init script that symlinks /dev/fd to /proc/self/fd per https://github.com/libbpf/ci/pull/44

Signed-off-by: Manu Bretelle <chantr4@gmail.com>