### PR TITLE
Add LLVM repo in a separate file

### DIFF
--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -10,7 +10,7 @@ sudo apt-get install -y g++ libelf-dev
 
 LLVM_VERSION=$(llvm_default_version)
 
-echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" | sudo tee -a /etc/apt/sources.list
+echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" | sudo tee /etc/apt/sources.list.d/llvm.list
 n=0
 while [ $n -lt 5 ]; do
   set +e && \


### PR DESCRIPTION
Put the repository in /etc/apt/sources.list.d/llvm.list instead of appending it to /etc/apt/sources.list.
This avoid having the repository duplicated multiple times.

While at it, switch from HTTP to HTTPS.