### PR TITLE
actions: Use new method to set output variables

### DIFF
--- a/get-llvm-version/action.yml
+++ b/get-llvm-version/action.yml
@@ -9,4 +9,4 @@ runs:
   steps:
     - id: llvm-version
       shell: bash
-      run: echo "::set-output name=version::$(source $GITHUB_ACTION_PATH/../helpers.sh; llvm_default_version)"
+      run: echo "version=$(source $GITHUB_ACTION_PATH/../helpers.sh; llvm_default_version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
set-output is being deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

the new recommended way is to write the name/valuer pain in
GITHUB_OUTPUT env file.

Fixes #47

Signed-off-by: Manu Bretelle <chantr4@gmail.com>