### PR TITLE
rootfs: Make rootfs init script work with busybox

### DIFF
--- a/rootfs/mkrootfs_tweak.sh
+++ b/rootfs/mkrootfs_tweak.sh
@@ -25,7 +25,7 @@ set -eux
 /bin/mount proc /proc -t proc
 
 # Mount devtmpfs if not mounted
-if [[ -z $(/bin/mount -t devtmpfs) ]]; then
+if [[ -z "$(/bin/mount -t devtmpfs)" ]]; then
 	/bin/mount devtmpfs /dev -t devtmpfs
 fi
 
@@ -34,7 +34,7 @@ fi
 /bin/mount debugfs /sys/kernel/debug -t debugfs
 
 # Symlink /dev/fd to /proc/self/fd so process substitution works.
-[[ -a /dev/fd ]] || ln -s /proc/self/fd /dev/fd
+[[ -e /dev/fd ]] || ln -s /proc/self/fd /dev/fd
 
 echo 'Listing currently mounted file systems'
 /bin/mount


### PR DESCRIPTION
The init scripts are run using busybox's `sh` which behaves differently than bash.

More specifically:
```
root@(none) /]# busybox sh
/ # [[ -z $(/bin/mount -t devtmpfs) ]]
sh: on: unknown operand
/ # [[ -a /dev/fd ]]
sh: /dev/fd: unknown operand
```

This change fixes the first issue by wrapping the command substitution in quotes, and changes `-a` test to `e` which seem to do the same thing.

Busybox documentation does not seem to have any reference about that.

With this change and an updated rootfs, the errors do not happen anymore:

```
  + [ -x /etc/rcS.d/S10-mount ]
  + /etc/rcS.d/S10-mount
  + /bin/mount proc /proc -t proc
  + /bin/mount -t devtmpfs
  + [[ -z devtmpfs on /dev type devtmpfs (rw,relatime,size=3029136k,nr_inodes=757284,mode=755) ]]
  + /bin/mount sysfs /sys -t sysfs
  + /bin/mount bpffs /sys/fs/bpf -t bpf
  + /bin/mount debugfs /sys/kernel/debug -t debugfs
  + [[ -e /dev/fd ]]
  + ln -s /proc/self/fd /dev/fd
  + echo Listing currently mounted file systems
  Listing currently mounted file systems
  + /bin/mount
```
Example run: https://github.com/kernel-patches/vmtest/actions/runs/3308807044/jobs/5462256604#step:6:425

Fixes #54
