### PR TITLE
rootfs: Fix init script errors #54

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -1,7 +1,7 @@
-x86_64/libbpf-vmtest-rootfs-2022.10.13-bullseye-amd64.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/libbpf-vmtest-rootfs-2022.10.13-bullseye-amd64.tar.zst
+x86_64/libbpf-vmtest-rootfs-2022.10.23-bullseye-amd64.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/libbpf-vmtest-rootfs-2022.10.23-bullseye-amd64.tar.zst
 x86_64/vmlinux-4.9.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-4.9.0.zst
 x86_64/vmlinux-5.5.0.zst	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst
 x86_64/vmlinuz-5.5.0	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0
 x86_64/vmlinuz-4.9.0	https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-4.9.0
-s390x/libbpf-vmtest-rootfs-2022.10.13-bullseye-s390x.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/libbpf-vmtest-rootfs-2022.10.13-bullseye-s390x.tar.zst
-aarch64/libbpf-vmtest-rootfs-2022.10.13-bullseye-arm64.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/libbpf-vmtest-rootfs-2022.10.13-bullseye-arm64.tar.zst
+s390x/libbpf-vmtest-rootfs-2022.10.23-bullseye-s390x.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/libbpf-vmtest-rootfs-2022.10.23-bullseye-s390x.tar.zst
+aarch64/libbpf-vmtest-rootfs-2022.10.23-bullseye-arm64.tar.zst	https://libbpf-ci.s3.us-west-1.amazonaws.com/libbpf-vmtest-rootfs-2022.10.23-bullseye-arm64.tar.zst


### PR DESCRIPTION
Those images were built with both #56 and #57 applied.

The former fixes building the rootfs for a foregin architecture and should not result in any material changes in the image.

The latter fixes an initscript to work when run with busybox'sh.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>