### PR TITLE
add shell linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,19 @@
+name: "lint"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -S error

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 # $1 - start or end
 # $2 - fold identifier, no spaces
 # $3 - fold section description

--- a/prepare-rootfs/run.sh
+++ b/prepare-rootfs/run.sh
@@ -438,7 +438,7 @@ chmod 644 /exitstatus
 HERE
 
 # Create the init scripts.
-if [[ ! -z SETUPCMD ]]; then
+if [[ -n $SETUPCMD ]]; then
 	# Unescape whitespace characters.
 	setup_cmd=$(sed 's/\(\\\)\([[:space:]]\)/\2/g' <<< "${SETUPCMD}")
 	kernel="${KERNELRELEASE}"


### PR DESCRIPTION
This adds a GitHub action which runs a shell linter on all the .sh files.
ludeeus/action-shellcheck is just an action which relies on
https://github.com/koalaman/shellcheck which is a well known linter.

```bash
~/src/libbpf-ci$ find -type f -name '*.sh' |xargs shellcheck -S error
~/src/libbpf-ci$ echo $?
0
```