### PR TITLE
run-qemu: Allow setting the maximum number of CPU to allocate to qemu

### DIFF
--- a/run-qemu/action.yml
+++ b/run-qemu/action.yml
@@ -13,6 +13,9 @@ inputs:
   kernel-root:
     description: 'kernel source dir'
     default: '.'
+  max-cpu:
+    description: 'Maximum number of CPU allocated to a VM (regardless of number of CPUs available on the host). Default is unset, e.g it will default to the number of CPU on the host.'
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -29,5 +32,6 @@ runs:
         VMLINUZ: ${{ inputs.vmlinuz }}
         IMG: ${{ inputs.img }}
         KERNEL_ROOT: ${{ inputs.kernel-root }}
+        MAX_CPU: ${{ inputs.max-cpu }}
       run: |
         ARCH="${{ inputs.arch }}" ${GITHUB_ACTION_PATH}/run.sh

--- a/run-qemu/run.sh
+++ b/run-qemu/run.sh
@@ -8,6 +8,8 @@ source $(cd $(dirname $0) && pwd)/../helpers.sh
 foldable start bpftool_checks "Running bpftool checks..."
 bpftool_exitstatus=0
 
+MAX_CPU=${MAX_CPU:-$(nproc)}
+
 # bpftool checks are aimed at checking type names, documentation, shell
 # completion etc. against the current kernel, so only run on LATEST.
 if [[ "${KERNEL}" = 'LATEST' ]]; then
@@ -63,13 +65,13 @@ aarch64)
 	;;
 esac
 
-smp=$((smp > 8 ? 8 : smp))
-
 if kvm-ok ; then
   accel=$kvm_accel
 else
   accel=$tcg_accel
 fi
+
+smp=$(( $smp > $MAX_CPU ? $MAX_CPU : $smp ))
 
 "$qemu" -nodefaults --no-reboot -nographic \
   -chardev stdio,id=char0,mux=on,signal=off,logfile=boot.log \


### PR DESCRIPTION
On aarch64 and x86_64, qemu will use the number of CPU available on the host. This change allow putting an upper-bound to this value by setting the `CPU_MAX` env variable.
If not specified, the value returned by `nproc` will be used.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>