### PR TITLE
Honor patches with .patch extension

### DIFF
--- a/patch-kernel/patch_kernel.sh
+++ b/patch-kernel/patch_kernel.sh
@@ -3,13 +3,15 @@
 set -eu
 DIFF_DIR=$1
 
-if ls ${DIFF_DIR}/*.diff 1>/dev/null 2>&1; then
-  for file in ${DIFF_DIR}/*.diff; do
-    if patch --dry-run -p1 -s < "${file}" 2>/dev/null; then
-      patch -s -p1 < "${file}" 2>/dev/null
-      echo "Successfully applied ${file}!"
-    else
-      echo "Failed to apply ${file}, skipping!"
-    fi
-  done
-fi
+for ext in diff patch; do
+  if ls ${DIFF_DIR}/*.${ext} 1>/dev/null 2>&1; then
+    for file in ${DIFF_DIR}/*.${ext}; do
+      if patch --dry-run -p1 -s < "${file}" 2>/dev/null; then
+        patch -s -p1 < "${file}" 2>/dev/null
+        echo "Successfully applied ${file}!"
+      else
+        echo "Failed to apply ${file}, skipping!"
+      fi
+    done
+  fi
+done


### PR DESCRIPTION
This change prepares the `patch-kernel` action for the application of patches with the extension `.patch`, in addition to `.diff`. The need to rename patches to sport the `.diff` extension has repeatedly been shown to be a difficult thing to remember.
See https://github.com/kernel-patches/vmtest/issues/160 for additional technical details.

Signed-off-by: Daniel Müller <deso@posteo.net>