### PR TITLE
Ansible for AWS runners

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -8,4 +8,3 @@
       when: ansible_architecture == "s390x"
     - role: runner
       tags: [runner]
-      when: ansible_architecture == "s390x"

--- a/ansible/roles/base/tasks/setup-RedHat.yml
+++ b/ansible/roles/base/tasks/setup-RedHat.yml
@@ -1,8 +1,14 @@
 ---
 - name: Install base packages
   become: true
-  dnf:
+  package:
     state: present
     name: "{{ base_packages }}"
     update_cache: yes
   tags: [install]
+
+- name: Start docker
+  become: true
+  service:
+    name: docker
+    state: started

--- a/ansible/roles/base/vars/RedHat.yml
+++ b/ansible/roles/base/vars/RedHat.yml
@@ -2,4 +2,5 @@
 
 __base_distro_packages:
   - "{{ 'podman-docker' if ansible_distribution != 'Amazon' else 'docker' }}"
+  - python3-pip
 

--- a/ansible/roles/base/vars/RedHat.yml
+++ b/ansible/roles/base/vars/RedHat.yml
@@ -1,4 +1,5 @@
 ---
 
 __base_distro_packages:
-  - podman-docker
+  - "{{ 'podman-docker' if ansible_distribution != 'Amazon' else 'docker' }}"
+

--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 runner_base_dir: /etc/actions-runner
 runner_workers: 1
+runner_prefix: ""
 runner_gh_token_default: replace with your token
 runner_gh_user_default: replace with your GH user
 runner_docker_tag: main

--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -12,3 +12,12 @@ runner_repo_list:
   - {name: owner1/repository1, instances: 2}
   - {name: owner1/repository2, instances: 1}
   - {name: owner2/repository2, instances: 1}
+
+#runner_gh_apps:
+#  - name: runner-app-name
+#    id: 1234
+#    secret: |
+#      ---START PEM SECRET---
+#      ...
+#      ...
+#      ---END PEM SECRET---

--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -2,6 +2,7 @@
 runner_base_dir: /etc/actions-runner
 runner_workers: 1
 runner_prefix: ""
+runner_workdir: /tmp/work
 runner_gh_token_default: replace with your token
 runner_gh_user_default: replace with your GH user
 runner_docker_tag: main

--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 runner_base_dir: /etc/actions-runner
 runner_gh_token_default: replace with your token
+runner_gh_user_default: replace with your GH user
 runner_gh_tokens:
   owner/repository: gh token for owner/repository
 runner_libbpf_ci_repo_url: https://github.com/libbpf/ci.git

--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -2,6 +2,7 @@
 runner_base_dir: /etc/actions-runner
 runner_gh_token_default: replace with your token
 runner_gh_user_default: replace with your GH user
+runner_docker_tag: main
 runner_gh_tokens:
   owner/repository: gh token for owner/repository
 runner_libbpf_ci_repo_url: https://github.com/libbpf/ci.git

--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 runner_base_dir: /etc/actions-runner
+runner_workers: 1
 runner_gh_token_default: replace with your token
 runner_gh_user_default: replace with your GH user
 runner_docker_tag: main

--- a/ansible/roles/runner/files/app_token.sh
+++ b/ansible/roles/runner/files/app_token.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Request an ACCESS_TOKEN to be used by a GitHub APP
+# Environment variable that need to be set up:
+# * APP_ID, the GitHub's app ID
+# * APP_PRIVATE_KEY, the content of GitHub app's private key in PEM format.
+#
+# https://github.com/orgs/community/discussions/24743#discussioncomment-3245300
+#
+
+set -o pipefail
+
+_GITHUB_HOST=${GITHUB_HOST:="github.com"}
+
+# If URL is not github.com then use the enterprise api endpoint
+if [[ ${GITHUB_HOST} = "github.com" ]]; then
+  URI="https://api.${_GITHUB_HOST}"
+else
+  URI="https://${_GITHUB_HOST}/api/v3"
+fi
+
+API_VERSION=v3
+API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
+CONTENT_LENGTH_HEADER="Content-Length: 0"
+APP_INSTALLATIONS_URI="${URI}/app/installations"
+
+
+# JWT parameters based off
+# https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app
+#
+# JWT token issuance and expiration parameters
+JWT_IAT_DRIFT=60
+JWT_EXP_DELTA=600
+
+JWT_JOSE_HEADER='{
+    "alg": "RS256",
+    "typ": "JWT"
+}'
+
+
+build_jwt_payload() {
+    now=$(date +%s)
+    iat=$((now - JWT_IAT_DRIFT))
+    jq -c \
+        --arg iat_str "${iat}" \
+        --arg exp_delta_str "${JWT_EXP_DELTA}" \
+        --arg app_id_str "${APP_ID}" \
+    '
+        ($iat_str | tonumber) as $iat
+        | ($exp_delta_str | tonumber) as $exp_delta
+        | ($app_id_str | tonumber) as $app_id
+        | .iat = $iat
+        | .exp = ($iat + $exp_delta)
+        | .iss = $app_id
+    ' <<< "{}" | tr -d '\n'
+}
+
+base64url() {
+    base64 | tr '+/' '-_' | tr -d '=\n'
+}
+
+rs256_sign() {
+    openssl dgst -binary -sha256 -sign <(echo "$1")
+}
+
+request_access_token() {
+    jwt_payload=$(build_jwt_payload)
+    encoded_jwt_parts=$(base64url <<<"${JWT_JOSE_HEADER}").$(base64url <<<"${jwt_payload}")
+    encoded_mac=$(echo -n "$encoded_jwt_parts" | rs256_sign "${APP_PRIVATE_KEY}" | base64url)
+    generated_jwt="${encoded_jwt_parts}.${encoded_mac}"
+
+    auth_header="Authorization: Bearer ${generated_jwt}"
+
+    app_installations_response=$(curl -sX GET \
+        -H "${auth_header}" \
+        -H "${API_HEADER}" \
+        ${APP_INSTALLATIONS_URI} \
+    )
+    access_token_url=$(echo "$app_installations_response" | jq --raw-output '.[] | select (.app_id  == '"${APP_ID}"') .access_tokens_url')
+    curl -sX POST \
+        -H "${CONTENT_LENGTH_HEADER}" \
+        -H "${auth_header}" \
+        -H "${API_HEADER}" \
+        "${access_token_url}" | \
+        jq --raw-output .token
+}
+
+request_access_token

--- a/ansible/roles/runner/files/gh_token_generator.sh
+++ b/ansible/roles/runner/files/gh_token_generator.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+SCRIPT_DIR=$(dirname "$0")
+APP_ID=$1
+APP_PRIVATE_KEY=$2
+DST_FILE="$3"
+
+ACCESS_TOKEN="$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="$(<"${APP_PRIVATE_KEY}")" "${SCRIPT_DIR}/app_token.sh")"
+echo "ACCESS_TOKEN=${ACCESS_TOKEN}" > "${DST_FILE}"

--- a/ansible/roles/runner/handlers/main.yml
+++ b/ansible/roles/runner/handlers/main.yml
@@ -18,3 +18,9 @@
   ansible.builtin.service:
     name: actions-runner-watchdog.timer
     state: restarted
+
+- name: "restart runner"
+  become: yes
+  ansible.builtin.service:
+    name: runner
+    state: restarted

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -65,7 +65,7 @@
 - name: Set runner.service
   become: yes
   ansible.builtin.copy:
-    dest: "{{ runner_base_dir }}/runner.service"
+    dest: "/etc/systemd/system/runner.service"
     content: |
       [Unit]
       Description=Ephemeral GitHub Actions Runner Container
@@ -87,3 +87,10 @@
   notify:
     - reload systemd daemon
     - restart runner
+
+- name: Start and enable runner service
+  become: yes
+  ansible.builtin.service:
+    name: runner
+    state: started
+    enabled: yes

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -1,12 +1,11 @@
 ---
 
 # Used by ansible modules later
-- name: Install docker/boto3 pip
+- name: Install docker pip
   become: yes
   ansible.builtin.pip:
     name:
       - docker
-      - boto3
     extra_args: --user
 
 - name: Set runner env
@@ -29,38 +28,27 @@
     - name: Load ec2 metadata facts
       amazon.aws.ec2_metadata_facts:
 
-    - name: Retrieve all tags on an instance
-      become: yes
-      amazon.aws.ec2_tag_info:
-        region: "{{ ansible_ec2_placement_region }}"
-        resource: "{{ ansible_ec2_instance_id }}"
-      register: instance_tags
+    - name: Set runner name prefix
+      set_fact:
+        runner_prefix: "{{ ansible_ec2_instance_id }}"
 
-    - name: Generate runner env file
-      become: yes
-      ansible.builtin.copy:
-        dest: "{{ runner_base_dir }}/actions-runner-{{ item.0.normalized }}-{{ 'worker-%02d.env' | format(item.1) }}"
-        content: |
-          ACCESS_TOKEN={{ runner_gh_token_default }}
-          RUNNER_WORKDIR=/tmp/work
-          LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
-          EPHEMERAL=true
-          REPO_URL=https://github.com/{{ item.0.name }}
-          RUNNER_NAME={{ ansible_ec2_instance_id }}-{{ 'worker-%02d' | format(item.1) }}
-      loop: "{{ runners | subelements('workers') }}"
   rescue:
-    - name: Generate runner env outside AWS
-      become: yes
-      ansible.builtin.copy:
-        dest: "{{ runner_base_dir }}/actions-runner-{{ item.0.normalized }}-{{ 'worker-%02d.env' | format(item.1) }}"
-        content: |
-          ACCESS_TOKEN={{ runner_gh_token_default }}
-          RUNNER_WORKDIR=/tmp/work
-          LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
-          EPHEMERAL=true
-          REPO_URL=https://github.com/{{ item.0.name }}
-          RUNNER_NAME={{ inventory_hostname }}-{{ 'worker-%02d' | format(item.1) }}
-      loop: "{{ runners | subelements('workers') }}"
+    - name: Set runner name prefix
+      set_fact:
+        runner_prefix: "{{ inventory_hostname }}"
+
+- name: Generate runner env outside AWS
+  become: yes
+  ansible.builtin.copy:
+    dest: "{{ runner_base_dir }}/actions-runner-{{ item.0.normalized }}-{{ 'worker-%02d.env' | format(item.1) }}"
+    content: |
+      ACCESS_TOKEN={{ runner_gh_token_default }}
+      RUNNER_WORKDIR=/tmp/work
+      LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
+      EPHEMERAL=true
+      REPO_URL=https://github.com/{{ item.0.name }}
+      RUNNER_NAME={{ runner_prefix }}-{{ 'worker-%02d' | format(item.1) }}
+  loop: "{{ runners | subelements('workers') }}"
 
 - name: Docker GHCR login
   become: yes

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -64,6 +64,11 @@
     username: "{{ runner_gh_user_default }}"
     password: "{{ runner_gh_token_default }}"
 
+- name: Check /dev/kvm exists
+  ansible.builtin.stat:
+    path: /dev/kvm
+  register: has_kvm
+
 - name: Set runner.service
   become: yes
   ansible.builtin.copy:
@@ -82,7 +87,7 @@
       ExecStartPre=-/usr/bin/docker rm %P-%i
       ExecStartPre=-/usr/bin/docker pull ghcr.io/kernel-patches/runner:${DOCKER_TAG}
       ExecStartPre=-/usr/bin/docker system prune -f
-      ExecStart=/usr/bin/docker run --rm --env-file "{{ runner_base_dir }}/runner_%i.env" --name %P-%i ghcr.io/kernel-patches/runner:${DOCKER_TAG}
+      ExecStart=/usr/bin/docker run {{ '--device=/dev/kvm' if has_kvm.stat.exists }} --rm --env-file "{{ runner_base_dir }}/runner_%i.env" --name %P-%i ghcr.io/kernel-patches/runner:${DOCKER_TAG}
     mode: 0700
     owner: root
     group: root

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -9,14 +9,17 @@
     extra_args: --user
     executable: pip3
 
-- name: Script to generate APP_TOKEN
+- name: Copy GH application token scripts
   become: yes
   ansible.builtin.copy:
-    src: app_token.sh
-    dest: "{{ runner_base_dir }}/app_token.sh"
+    src: "{{ item }}"
+    dest: "{{ runner_base_dir }}/{{ item }}"
     mode: 0755
     owner: root
     group: root
+  with_items:
+    - app_token.sh
+    - gh_token_generator.sh
 
 - name: Write App private key
   no_log: true
@@ -87,7 +90,12 @@
   become: yes
   ansible.builtin.copy:
     dest: "/etc/systemd/system/actions-runner-{{ item.normalized }}@.service"
+    # The use of `namespace` is needed. See Jinja scoping: https://jinja.palletsprojects.com/en/3.1.x/templates/#assignments
     content: |
+      {% set ns = namespace(ghapp=undefined) %}
+      {% for runner_gh_app in runner_gh_apps if runner_gh_app.id == item.gh_app_id %}
+        {%- set ns.ghapp = runner_gh_app %}
+      {%- endfor %}
       [Unit]
       Description=Ephemeral GitHub Actions Runner Container for {{ item.name }} - %i
       After=docker.service
@@ -100,9 +108,15 @@
       ExecStartPre=-/usr/bin/docker stop %p-%i
       ExecStartPre=-/usr/bin/docker rm %p-%i
       ExecStartPre=-/usr/bin/docker pull ghcr.io/kernel-patches/runner:${DOCKER_TAG}
+      {% if ns.ghapp is defined %}
+      ExecStartPre=-{{ runner_base_dir }}/gh_token_generator.sh {{ ns.ghapp.id }} "{{ runner_base_dir }}/{{ ns.ghapp.name }}_{{ ns.ghapp.id }}_priv.pem" "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i-ghtoken.env"
+      {% endif %}
       ExecStart=/usr/bin/docker run {{ '--device=/dev/kvm' if has_kvm.stat.exists }} \
                   --rm \
                   --env-file "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i.env" \
+      {% if ns.ghapp is defined %}
+                  --env-file "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i-ghtoken.env" \
+      {% endif %}
                   --name %p-%i \
                   ghcr.io/kernel-patches/runner:${DOCKER_TAG}
     mode: 0700

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -9,6 +9,26 @@
     extra_args: --user
     executable: pip3
 
+- name: Script to generate APP_TOKEN
+  become: yes
+  ansible.builtin.copy:
+    src: app_token.sh
+    dest: "{{ runner_base_dir }}/app_token.sh"
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Write App private key
+  no_log: true
+  become: yes
+  ansible.builtin.copy:
+    content: "{{ item.secret }}"
+    dest: "{{ runner_base_dir }}/{{ item.name }}_{{ item.id }}_priv.pem"
+    mode: 0700
+    owner: root
+    group: root
+  with_items: "{{ runner_gh_apps |default([]) }}"
+
 - name: Set runner env
   become: yes
   ansible.builtin.copy:

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -19,27 +19,41 @@
     owner: root
     group: root
 
-- name: Load ec2 metadata facts
-  amazon.aws.ec2_metadata_facts:
+- name: Generate runner environment file
+  block:
+    - name: Load ec2 metadata facts
+      amazon.aws.ec2_metadata_facts:
 
-- name: Retrieve all tags on an instance
-  become: yes
-  amazon.aws.ec2_tag_info:
-    region: "{{ ansible_ec2_placement_region }}"
-    resource: "{{ ansible_ec2_instance_id }}"
-  register: instance_tags
+    - name: Retrieve all tags on an instance
+      become: yes
+      amazon.aws.ec2_tag_info:
+        region: "{{ ansible_ec2_placement_region }}"
+        resource: "{{ ansible_ec2_instance_id }}"
+      register: instance_tags
 
-- name: Generate runner env file
-  become: yes
-  ansible.builtin.copy:
-    dest: "{{ runner_base_dir }}/runner.env"
-    content: |
-      ACCESS_TOKEN={{ runner_gh_token_default }}
-      RUNNER_WORKDIR=/tmp/work
-      LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
-      EPHEMERAL=true
-      REPO_URL={{ instance_tags.tags['Repo'] }}
-      RUNNER_NAME={{ ansible_ec2_instance_id }}
+    - name: Generate runner env file within AWS
+      become: yes
+      ansible.builtin.copy:
+        dest: "{{ runner_base_dir }}/runner.env"
+        content: |
+          ACCESS_TOKEN={{ runner_gh_token_default }}
+          RUNNER_WORKDIR=/tmp/work
+          LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
+          EPHEMERAL=true
+          REPO_URL={{ instance_tags.tags['Repo'] }}
+          RUNNER_NAME={{ ansible_ec2_instance_id }}
+  rescue:
+    - name: Generate runner env outside AWS
+      become: yes
+      ansible.builtin.copy:
+        dest: "{{ runner_base_dir }}/runner.env"
+        content: |
+          ACCESS_TOKEN={{ runner_gh_token_default }}
+          RUNNER_WORKDIR=/tmp/work
+          LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
+          EPHEMERAL=true
+          REPO_URL=https://github.com/{{ runner_repo_list[0].name }}
+          RUNNER_NAME={{ inventory_hostname }}
 
 - name: Docker GHCR login
   become: yes

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -80,7 +80,6 @@
       ExecStartPre=-/usr/bin/docker stop %p-%i
       ExecStartPre=-/usr/bin/docker rm %p-%i
       ExecStartPre=-/usr/bin/docker pull ghcr.io/kernel-patches/runner:${DOCKER_TAG}
-      ExecStartPre=-/usr/bin/docker system prune -f
       ExecStart=/usr/bin/docker run {{ '--device=/dev/kvm' if has_kvm.stat.exists }} \
                   --rm \
                   --env-file "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i.env" \

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -70,7 +70,13 @@
       RUNNER_WORKDIR={{ runner_workdir }}
       LABELS=ubuntu-latest,{{ ansible_architecture }},docker-{{ runner_docker_tag }}
       EPHEMERAL=true
+      {% if '/' in item.0.name %}
+      {# The presence of a / in the name signifies that we have a repo name, otherwise we assume an organization name. #}
       REPO_URL=https://github.com/{{ item.0.name }}
+      {% else %}
+      RUNNER_SCOPE=org
+      ORG_NAME={{ item.0.name }}
+      {% endif %}
       RUNNER_NAME={{ runner_name_prefix }}-{{ 'worker-%02d' | format(item.1) }}
   loop: "{{ runners | subelements('workers') }}"
 

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -54,12 +54,12 @@
 
     - name: Set runner name prefix
       set_fact:
-        runner_prefix: "{{ ansible_ec2_instance_id }}"
+        runner_name_prefix: "{{ '%s-' | format(runner_prefix) if runner_prefix }}{{ ansible_ec2_instance_id }}"
 
   rescue:
     - name: Set runner name prefix
       set_fact:
-        runner_prefix: "{{ ansible_hostname }}"
+        runner_name_prefix: "{{ '%s-' | format(runner_prefix) if runner_prefix }}{{ ansible_hostname }}"
 
 - name: Generate runner env outside AWS
   become: yes
@@ -71,7 +71,7 @@
       LABELS=ubuntu-latest,{{ ansible_architecture }},docker-{{ runner_docker_tag }}
       EPHEMERAL=true
       REPO_URL=https://github.com/{{ item.0.name }}
-      RUNNER_NAME={{ runner_prefix }}-{{ 'worker-%02d' | format(item.1) }}
+      RUNNER_NAME={{ runner_name_prefix }}-{{ 'worker-%02d' | format(item.1) }}
   loop: "{{ runners | subelements('workers') }}"
 
 - name: Docker GHCR login

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -19,6 +19,11 @@
     owner: root
     group: root
 
+- name: Generate runners facts
+  set_fact:
+    runners: "{{ runners|default([]) + [ {'normalized': item.name | replace('/','-'), 'workers': range(item.instances) | list }  | combine(item) ] }}"
+  with_items: "{{ runner_repo_list }}"
+
 - name: Generate runner environment file
   block:
     - name: Load ec2 metadata facts
@@ -34,28 +39,28 @@
     - name: Generate runner env file
       become: yes
       ansible.builtin.copy:
-        dest: "{{ runner_base_dir }}/{{ 'runner_%02d.env' | format(item) }}"
+        dest: "{{ runner_base_dir }}/actions-runner-{{ item.0.normalized }}-{{ 'worker-%02d.env' | format(item.1) }}"
         content: |
           ACCESS_TOKEN={{ runner_gh_token_default }}
           RUNNER_WORKDIR=/tmp/work
           LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
           EPHEMERAL=true
-          REPO_URL={{ instance_tags.tags['Repo'] }}
-          RUNNER_NAME={{ ansible_ec2_instance_id }}-{{ 'worker-%02d' | format(item) }}
-      loop: "{{ range(0, runner_workers, 1)|list }}"
+          REPO_URL=https://github.com/{{ item.0.name }}
+          RUNNER_NAME={{ ansible_ec2_instance_id }}-{{ 'worker-%02d' | format(item.1) }}
+      loop: "{{ runners | subelements('workers') }}"
   rescue:
     - name: Generate runner env outside AWS
       become: yes
       ansible.builtin.copy:
-        dest: "{{ runner_base_dir }}/{{ 'runner_%02d.env' | format(item) }}"
+        dest: "{{ runner_base_dir }}/actions-runner-{{ item.0.normalized }}-{{ 'worker-%02d.env' | format(item.1) }}"
         content: |
           ACCESS_TOKEN={{ runner_gh_token_default }}
           RUNNER_WORKDIR=/tmp/work
           LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
           EPHEMERAL=true
-          REPO_URL=https://github.com/{{ runner_repo_list[0].name }}
-          RUNNER_NAME={{ inventory_hostname }}-{{ 'worker-%02d' | format(item) }}
-      loop: "{{ range(0, runner_workers, 1)|list }}"
+          REPO_URL=https://github.com/{{ item.0.name }}
+          RUNNER_NAME={{ inventory_hostname }}-{{ 'worker-%02d' | format(item.1) }}
+      loop: "{{ runners | subelements('workers') }}"
 
 - name: Docker GHCR login
   become: yes
@@ -72,10 +77,10 @@
 - name: Set runner.service
   become: yes
   ansible.builtin.copy:
-    dest: "/etc/systemd/system/runner@.service"
+    dest: "/etc/systemd/system/actions-runner-{{ item.normalized }}@.service"
     content: |
       [Unit]
-      Description=Ephemeral GitHub Actions Runner Container %i
+      Description=Ephemeral GitHub Actions Runner Container for {{ item.name }} - %i
       After=docker.service
       Requires=docker.service
 
@@ -83,21 +88,26 @@
       TimeoutStartSec=0
       Restart=always
       EnvironmentFile={{ runner_base_dir }}/runner_unit.env
-      ExecStartPre=-/usr/bin/docker stop %P-%i
-      ExecStartPre=-/usr/bin/docker rm %P-%i
+      ExecStartPre=-/usr/bin/docker stop %p-%i
+      ExecStartPre=-/usr/bin/docker rm %p-%i
       ExecStartPre=-/usr/bin/docker pull ghcr.io/kernel-patches/runner:${DOCKER_TAG}
       ExecStartPre=-/usr/bin/docker system prune -f
-      ExecStart=/usr/bin/docker run {{ '--device=/dev/kvm' if has_kvm.stat.exists }} --rm --env-file "{{ runner_base_dir }}/runner_%i.env" --name %P-%i ghcr.io/kernel-patches/runner:${DOCKER_TAG}
+      ExecStart=/usr/bin/docker run {{ '--device=/dev/kvm' if has_kvm.stat.exists }} \
+                  --rm \
+                  --env-file "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i.env" \
+                  --name %p-%i \
+                  ghcr.io/kernel-patches/runner:${DOCKER_TAG}
     mode: 0700
     owner: root
     group: root
+  loop: "{{ runners }}"
   notify:
     - reload systemd daemon
 
 - name: Start and enable runner services
   become: yes
   ansible.builtin.service:
-    name: "{{ 'runner@%02d' | format(item) }}"
+    name: "{{ 'actions-runner-%s@%02d' | format(item.0.normalized, item.1) }}"
     state: started
     enabled: yes
-  loop: "{{ range(0, runner_workers, 1)|list }}"
+  loop: "{{ runners | subelements('workers') }}"

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -44,7 +44,7 @@
     content: |
       ACCESS_TOKEN={{ runner_gh_token_default }}
       RUNNER_WORKDIR=/tmp/work
-      LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
+      LABELS=ubuntu-latest,{{ ansible_architecture }},docker-{{ runner_docker_tag }}
       EPHEMERAL=true
       REPO_URL=https://github.com/{{ item.0.name }}
       RUNNER_NAME={{ runner_prefix }}-{{ 'worker-%02d' | format(item.1) }}

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -35,7 +35,7 @@
   rescue:
     - name: Set runner name prefix
       set_fact:
-        runner_prefix: "{{ inventory_hostname }}"
+        runner_prefix: "{{ ansible_hostname }}"
 
 - name: Generate runner env outside AWS
   become: yes

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -67,7 +67,7 @@
     dest: "{{ runner_base_dir }}/actions-runner-{{ item.0.normalized }}-{{ 'worker-%02d.env' | format(item.1) }}"
     content: |
       ACCESS_TOKEN={{ runner_gh_token_default }}
-      RUNNER_WORKDIR=/tmp/work
+      RUNNER_WORKDIR={{ runner_workdir }}
       LABELS=ubuntu-latest,{{ ansible_architecture }},docker-{{ runner_docker_tag }}
       EPHEMERAL=true
       REPO_URL=https://github.com/{{ item.0.name }}
@@ -111,7 +111,7 @@
       {% if ns.ghapp is defined %}
       ExecStartPre=-{{ runner_base_dir }}/gh_token_generator.sh {{ ns.ghapp.id }} "{{ runner_base_dir }}/{{ ns.ghapp.name }}_{{ ns.ghapp.id }}_priv.pem" "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i-ghtoken.env"
       {% endif %}
-      ExecStart=/usr/bin/docker run {{ '--device=/dev/kvm' if has_kvm.stat.exists }} \
+      ExecStart=/usr/bin/docker run {{ '--device=/dev/kvm --tmpfs %s:exec' | format(runner_workdir) if has_kvm.stat.exists }} \
                   --rm \
                   --env-file "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i.env" \
       {% if ns.ghapp is defined %}

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -31,29 +31,31 @@
         resource: "{{ ansible_ec2_instance_id }}"
       register: instance_tags
 
-    - name: Generate runner env file within AWS
+    - name: Generate runner env file
       become: yes
       ansible.builtin.copy:
-        dest: "{{ runner_base_dir }}/runner.env"
+        dest: "{{ runner_base_dir }}/{{ 'runner_%02d.env' | format(item) }}"
         content: |
           ACCESS_TOKEN={{ runner_gh_token_default }}
           RUNNER_WORKDIR=/tmp/work
           LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
           EPHEMERAL=true
           REPO_URL={{ instance_tags.tags['Repo'] }}
-          RUNNER_NAME={{ ansible_ec2_instance_id }}
+          RUNNER_NAME={{ ansible_ec2_instance_id }}-{{ 'worker-%02d' | format(item) }}
+      loop: "{{ range(0, runner_workers, 1)|list }}"
   rescue:
     - name: Generate runner env outside AWS
       become: yes
       ansible.builtin.copy:
-        dest: "{{ runner_base_dir }}/runner.env"
+        dest: "{{ runner_base_dir }}/{{ 'runner_%02d.env' | format(item) }}"
         content: |
           ACCESS_TOKEN={{ runner_gh_token_default }}
           RUNNER_WORKDIR=/tmp/work
           LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
           EPHEMERAL=true
           REPO_URL=https://github.com/{{ runner_repo_list[0].name }}
-          RUNNER_NAME={{ inventory_hostname }}
+          RUNNER_NAME={{ inventory_hostname }}-{{ 'worker-%02d' | format(item) }}
+      loop: "{{ range(0, runner_workers, 1)|list }}"
 
 - name: Docker GHCR login
   become: yes
@@ -65,10 +67,10 @@
 - name: Set runner.service
   become: yes
   ansible.builtin.copy:
-    dest: "/etc/systemd/system/runner.service"
+    dest: "/etc/systemd/system/runner@.service"
     content: |
       [Unit]
-      Description=Ephemeral GitHub Actions Runner Container
+      Description=Ephemeral GitHub Actions Runner Container %i
       After=docker.service
       Requires=docker.service
 
@@ -76,21 +78,21 @@
       TimeoutStartSec=0
       Restart=always
       EnvironmentFile={{ runner_base_dir }}/runner_unit.env
-      ExecStartPre=-/usr/bin/docker stop %n
-      ExecStartPre=-/usr/bin/docker rm %n
+      ExecStartPre=-/usr/bin/docker stop %P-%i
+      ExecStartPre=-/usr/bin/docker rm %P-%i
       ExecStartPre=-/usr/bin/docker pull ghcr.io/kernel-patches/runner:${DOCKER_TAG}
       ExecStartPre=-/usr/bin/docker system prune -f
-      ExecStart=/usr/bin/docker run --rm --env-file "{{ runner_base_dir }}/runner.env" --name %n ghcr.io/kernel-patches/runner:${DOCKER_TAG}
+      ExecStart=/usr/bin/docker run --rm --env-file "{{ runner_base_dir }}/runner_%i.env" --name %P-%i ghcr.io/kernel-patches/runner:${DOCKER_TAG}
     mode: 0700
     owner: root
     group: root
   notify:
     - reload systemd daemon
-    - restart runner
 
-- name: Start and enable runner service
+- name: Start and enable runner services
   become: yes
   ansible.builtin.service:
-    name: runner
+    name: "{{ 'runner@%02d' | format(item) }}"
     state: started
     enabled: yes
+  loop: "{{ range(0, runner_workers, 1)|list }}"

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -7,6 +7,7 @@
     name:
       - docker
     extra_args: --user
+    executable: pip3
 
 - name: Set runner env
   become: yes

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -1,0 +1,108 @@
+---
+
+- name: Set runner env
+  become: yes
+  ansible.builtin.copy:
+    dest: "{{ runner_base_dir }}/runner_unit.env"
+    content: |
+      DOCKER_TAG=main
+    mode: 0700
+    owner: root
+    group: root
+
+- name: Generate Env script
+  become: yes
+  ansible.builtin.copy:
+    dest: "{{ runner_base_dir }}/generate-env.sh"
+    content: |
+      #!/bin/bash
+
+      THISDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+      . $THISDIR/runner_unit.env
+
+
+      echo "ACCESS_TOKEN={{ runner_gh_token_default }}
+      RUNNER_WORKDIR=/tmp/work
+      LABELS=ubuntu-latest,docker-${DOCKER_TAG}
+      EPHEMERAL=true" > $THISDIR/runner.env
+
+      echo "REPO_URL=$($THISDIR/tags.sh Repo)" >> $THISDIR/runner.env
+      echo "RUNNER_NAME=$($THISDIR/instanceid.sh)" >> $THISDIR/runner.env
+    mode: 0700
+    owner: root
+    group: root
+
+- name: Tags script
+  become: yes
+  ansible.builtin.copy:
+    dest: "{{ runner_base_dir }}/tags.sh"
+    content: |
+      #!/bin/bash
+
+      REGION=`curl -s http://169.254.169.254/latest/dynamic/instance-identity/document|grep region|awk -F\" -e '{print $4}'`
+      instance_id=$(/usr/bin/curl --silent http://169.254.169.254/latest/meta-data/instance-id)
+
+      if [ -z "$1" ]; then
+              echo $(/usr/bin/aws ec2 describe-tags --filters "Name=resource-id,Values=$instance_id" --region=$REGION --output=json | jq --raw-output \
+              ".Tags[]")
+      else
+              echo $(/usr/bin/aws ec2 describe-tags --filters "Name=resource-id,Values=$instance_id" --region=$REGION --output=json | jq --raw-output \
+              ".Tags[] | select(.Key==\"$1\") | .Value")
+      fi
+    mode: 0700
+    owner: root
+    group: root
+
+- name: Instanceid script
+  become: yes
+  ansible.builtin.copy:
+    dest: "{{ runner_base_dir }}/instanceid.sh"
+    content: |
+      #!/bin/bash
+
+      /usr/bin/curl --silent http://169.254.169.254/latest/meta-data/instance-id
+    mode: 0700
+    owner: root
+    group: root
+
+- name: Install docker pip
+  become: yes
+  ansible.builtin.pip:
+    name:
+      docker
+    extra_args: --user
+
+- name: Docker GHCR login
+  become: yes
+  docker_login:
+    registry: ghcr.io
+    username: "{{ runner_gh_user_default }}"
+    password: "{{ runner_gh_token_default }}"
+
+- name: Set runner.service
+  become: yes
+  ansible.builtin.copy:
+    dest: "{{ runner_base_dir }}/runner.service"
+    content: |
+      [Unit]
+      Description=Ephemeral GitHub Actions Runner Container
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      TimeoutStartSec=0
+      Restart=always
+      EnvironmentFile={{ runner_base_dir }}/runner_unit.env
+      ExecStartPre=-/usr/bin/docker stop %n
+      ExecStartPre=-/usr/bin/docker rm %n
+      ExecStartPre=-/usr/bin/docker pull ghcr.io/kernel-patches/runner:${DOCKER_TAG}
+      ExecStartPre=-/usr/bin/docker system prune -f
+      ExecStartPre={{ runner_base_dir }}/generate-env.sh
+      ExecStart=/usr/bin/docker run --rm --env-file "{{ runner_base_dir }}/runner.env" --name %n ghcr.io/kernel-patches/runner:${DOCKER_TAG}
+    mode: 0700
+    owner: root
+    group: root
+  notify:
+    - reload systemd daemon
+    - restart runner

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -119,6 +119,9 @@
       {% endif %}
                   --name %p-%i \
                   ghcr.io/kernel-patches/runner:${DOCKER_TAG}
+
+      [Install]
+      WantedBy=multi-user.target
     mode: 0700
     owner: root
     group: root

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -1,77 +1,45 @@
 ---
 
+# Used by ansible modules later
+- name: Install docker/boto3 pip
+  become: yes
+  ansible.builtin.pip:
+    name:
+      - docker
+      - boto3
+    extra_args: --user
+
 - name: Set runner env
   become: yes
   ansible.builtin.copy:
     dest: "{{ runner_base_dir }}/runner_unit.env"
     content: |
-      DOCKER_TAG=main
+      DOCKER_TAG={{ runner_docker_tag }}
     mode: 0700
     owner: root
     group: root
 
-- name: Generate Env script
+- name: Load ec2 metadata facts
+  amazon.aws.ec2_metadata_facts:
+
+- name: Retrieve all tags on an instance
+  become: yes
+  amazon.aws.ec2_tag_info:
+    region: "{{ ansible_ec2_placement_region }}"
+    resource: "{{ ansible_ec2_instance_id }}"
+  register: instance_tags
+
+- name: Generate runner env file
   become: yes
   ansible.builtin.copy:
-    dest: "{{ runner_base_dir }}/generate-env.sh"
+    dest: "{{ runner_base_dir }}/runner.env"
     content: |
-      #!/bin/bash
-
-      THISDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-      . $THISDIR/runner_unit.env
-
-
-      echo "ACCESS_TOKEN={{ runner_gh_token_default }}
+      ACCESS_TOKEN={{ runner_gh_token_default }}
       RUNNER_WORKDIR=/tmp/work
-      LABELS=ubuntu-latest,docker-${DOCKER_TAG}
-      EPHEMERAL=true" > $THISDIR/runner.env
-
-      echo "REPO_URL=$($THISDIR/tags.sh Repo)" >> $THISDIR/runner.env
-      echo "RUNNER_NAME=$($THISDIR/instanceid.sh)" >> $THISDIR/runner.env
-    mode: 0700
-    owner: root
-    group: root
-
-- name: Tags script
-  become: yes
-  ansible.builtin.copy:
-    dest: "{{ runner_base_dir }}/tags.sh"
-    content: |
-      #!/bin/bash
-
-      REGION=`curl -s http://169.254.169.254/latest/dynamic/instance-identity/document|grep region|awk -F\" -e '{print $4}'`
-      instance_id=$(/usr/bin/curl --silent http://169.254.169.254/latest/meta-data/instance-id)
-
-      if [ -z "$1" ]; then
-              echo $(/usr/bin/aws ec2 describe-tags --filters "Name=resource-id,Values=$instance_id" --region=$REGION --output=json | jq --raw-output \
-              ".Tags[]")
-      else
-              echo $(/usr/bin/aws ec2 describe-tags --filters "Name=resource-id,Values=$instance_id" --region=$REGION --output=json | jq --raw-output \
-              ".Tags[] | select(.Key==\"$1\") | .Value")
-      fi
-    mode: 0700
-    owner: root
-    group: root
-
-- name: Instanceid script
-  become: yes
-  ansible.builtin.copy:
-    dest: "{{ runner_base_dir }}/instanceid.sh"
-    content: |
-      #!/bin/bash
-
-      /usr/bin/curl --silent http://169.254.169.254/latest/meta-data/instance-id
-    mode: 0700
-    owner: root
-    group: root
-
-- name: Install docker pip
-  become: yes
-  ansible.builtin.pip:
-    name:
-      docker
-    extra_args: --user
+      LABELS=ubuntu-latest,docker-{{ runner_docker_tag }}
+      EPHEMERAL=true
+      REPO_URL={{ instance_tags.tags['Repo'] }}
+      RUNNER_NAME={{ ansible_ec2_instance_id }}
 
 - name: Docker GHCR login
   become: yes
@@ -98,7 +66,6 @@
       ExecStartPre=-/usr/bin/docker rm %n
       ExecStartPre=-/usr/bin/docker pull ghcr.io/kernel-patches/runner:${DOCKER_TAG}
       ExecStartPre=-/usr/bin/docker system prune -f
-      ExecStartPre={{ runner_base_dir }}/generate-env.sh
       ExecStart=/usr/bin/docker run --rm --env-file "{{ runner_base_dir }}/runner.env" --name %n ghcr.io/kernel-patches/runner:${DOCKER_TAG}
     mode: 0700
     owner: root

--- a/ansible/roles/runner/tasks/main-generic.yml
+++ b/ansible/roles/runner/tasks/main-generic.yml
@@ -68,7 +68,7 @@
     content: |
       ACCESS_TOKEN={{ runner_gh_token_default }}
       RUNNER_WORKDIR={{ runner_workdir }}
-      LABELS=ubuntu-latest,{{ ansible_architecture }},docker-{{ runner_docker_tag }}
+      LABELS={{ ansible_architecture }},docker-{{ runner_docker_tag }}
       EPHEMERAL=true
       {% if '/' in item.0.name %}
       {# The presence of a / in the name signifies that we have a repo name, otherwise we assume an organization name. #}


### PR DESCRIPTION
This stack does quite a few things:
- allow setting runners with ansible on AWS
-  use kvm when pssible (bare-metal) and also allow setting multiple runners per repo
- add architecture in the runner label see kernel-patches/vmtest#162 for context.
- add support to run runners using a GH app instead of a GH user, this helps runners not being impacted/impact rate limiting
- add a runner prefix