### PR TITLE
ansible: move docker pruning service in main.yml

### DIFF
--- a/ansible/roles/runner/tasks/main-s390x.yml
+++ b/ansible/roles/runner/tasks/main-s390x.yml
@@ -65,52 +65,6 @@
   loop: "{{ runners | subelements('workers') }}"
 
 
-- name: Set docker pruning service
-  become: yes
-  ansible.builtin.copy:
-    dest: /etc/systemd/system/docker_pruning.service
-    content: |
-      [Unit]
-      Description=Prune unused docker resources
-      Wants=docker_pruning.timer
-
-      [Service]
-      Type=oneshot
-      ExecStart=/usr/bin/docker system prune --volumes -f
-    mode: 0644
-    owner: root
-    group: root
-  notify:
-    - reload systemd daemon
-    - restart docker_pruning timer
-
-
-- name: Set docker pruning timer
-  become: yes
-  ansible.builtin.copy:
-    dest: /etc/systemd/system/docker_pruning.timer
-    content: |
-      [Unit]
-      Description=Run docker_pruning service daily
-
-      [Timer]
-      # Run at 8:00 UTC daily
-      OnCalendar=*-*-* 08:00:00
-      [Install]
-      WantedBy=timers.target
-    mode: 0644
-    owner: root
-    group: root
-  notify:
-    - reload systemd daemon
-    - restart docker_pruning timer
-
-- name: Enable docker pruning timer
-  become: yes
-  ansible.builtin.service:
-    name: docker_pruning.timer
-    enabled: yes
-    state: started
 
 # Watchdog
 - name: Actions runner watchdog script

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -12,3 +12,50 @@
 
 - include_tasks: main-generic.yml
   when: ansible_architecture != 's390x'
+
+- name: Set docker pruning service
+  become: yes
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/docker_pruning.service
+    content: |
+      [Unit]
+      Description=Prune unused docker resources
+      Wants=docker_pruning.timer
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/docker system prune --volumes -f
+    mode: 0644
+    owner: root
+    group: root
+  notify:
+    - reload systemd daemon
+    - restart docker_pruning timer
+
+
+- name: Set docker pruning timer
+  become: yes
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/docker_pruning.timer
+    content: |
+      [Unit]
+      Description=Run docker_pruning service daily
+
+      [Timer]
+      # Run at 8:00 UTC daily
+      OnCalendar=*-*-* 08:00:00
+      [Install]
+      WantedBy=timers.target
+    mode: 0644
+    owner: root
+    group: root
+  notify:
+    - reload systemd daemon
+    - restart docker_pruning timer
+
+- name: Enable docker pruning timer
+  become: yes
+  ansible.builtin.service:
+    name: docker_pruning.timer
+    enabled: yes
+    state: started


### PR DESCRIPTION
This is useful for both AWS (to come in libbpf/ci#69) and s390x.

Moving it into main.yml so it gets applied to both.

Test run shows it will still be installed on s390x

```
$ ansible-playbook   -i ./inventory.yml ./playbook.yml  --limit bpf-ci-runner-s390x-5 --tag runner  -C -D

PLAY [all] ***********************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Create runner directory] ******************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : include_tasks] ****************************************************************************************************************************************************************
included: /home/chantra/devel/libbpf/ci/ansible/roles/runner/tasks/main-s390x.yml for bpf-ci-runner-s390x-5

TASK [runner : Get account $HOME] ************************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Generate runners facts] *******************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5] => (item={'name': 'kernel-patches/bpf', 'instances': 2})

TASK [runner : Sync libbpf/ci repo] **********************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Build runner docker image] ****************************************************************************************************************************************************
skipping: [bpf-ci-runner-s390x-5] => (item={'normalized': 'kernel-patches-bpf', 'workers': [0, 1], 'name': 'kernel-patches/bpf', 'instances': 2})

TASK [runner : Runner configuration file] ****************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5] => (item=[{'normalized': 'kernel-patches-bpf', 'workers': [0, 1], 'name': 'kernel-patches/bpf', 'instances': 2}, 0])
ok: [bpf-ci-runner-s390x-5] => (item=[{'normalized': 'kernel-patches-bpf', 'workers': [0, 1], 'name': 'kernel-patches/bpf', 'instances': 2}, 1])

TASK [runner : Runner systemd unit] **********************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5] => (item={'normalized': 'kernel-patches-bpf', 'workers': [0, 1], 'name': 'kernel-patches/bpf', 'instances': 2})

TASK [runner : Enable runner service] ********************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5] => (item=[{'normalized': 'kernel-patches-bpf', 'workers': [0, 1], 'name': 'kernel-patches/bpf', 'instances': 2}, 0])
ok: [bpf-ci-runner-s390x-5] => (item=[{'normalized': 'kernel-patches-bpf', 'workers': [0, 1], 'name': 'kernel-patches/bpf', 'instances': 2}, 1])

TASK [runner : Actions runner watchdog script] ***********************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Set actions runner watchdog service] ******************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Set actions runner watchdog timer] ********************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Enable actions runner watchdog timer] *****************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : include_tasks] ****************************************************************************************************************************************************************
skipping: [bpf-ci-runner-s390x-5]

TASK [runner : Set docker pruning service] ***************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Set docker pruning timer] *****************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

TASK [runner : Enable docker pruning timer] **************************************************************************************************************************************************
ok: [bpf-ci-runner-s390x-5]

PLAY RECAP ***********************************************************************************************************************************************************************************
bpf-ci-runner-s390x-5      : ok=16   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```
Signed-off-by: Manu Bretelle <chantr4@gmail.com>