### PR TITLE
build: Add environment variable to pin the maximum number of processes to be used by make

### DIFF
--- a/build-linux/action.yml
+++ b/build-linux/action.yml
@@ -10,6 +10,9 @@ inputs:
   kbuild-output:
     description: 'relative or absolute path to use for storing build artifacts'
     default: '.'
+  max-make-jobs:
+    description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -18,3 +21,5 @@ runs:
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
         ${GITHUB_ACTION_PATH}/build.sh "${{ inputs.arch }}" "${{ inputs.toolchain }}" "${kbuild_output}"
+      env:
+        MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -23,6 +23,6 @@ cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config \
     ${GITHUB_WORKSPACE}/ci/vmtest/configs/config \
     ${GITHUB_WORKSPACE}/ci/vmtest/configs/config.${ARCH} 2> /dev/null > "${KBUILD_OUTPUT}"/.config && :
 
-make -j $((4*$(nproc))) olddefconfig all
+make -j $(kernel_build_make_jobs) olddefconfig all
 
 foldable end build_kernel

--- a/build-samples/action.yml
+++ b/build-samples/action.yml
@@ -14,6 +14,10 @@ inputs:
   kbuild-output:
     description: 'relative or absolute path to use for storing build artifacts'
     default: '.'
+  max-make-jobs:
+    description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
+    default: ''
+
 runs:
   using: "composite"
   steps:
@@ -22,3 +26,5 @@ runs:
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
         ${GITHUB_ACTION_PATH}/build_samples.sh "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
+      env:
+        MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-samples/build_samples.sh
+++ b/build-samples/build_samples.sh
@@ -35,6 +35,6 @@ make \
 	VMLINUX_BTF="${KBUILD_OUTPUT}/vmlinux" \
 	VMLINUX_H="${VMLINUX_H}" \
 	-C "${REPO_ROOT}/${REPO_PATH}/samples/bpf" \
-	-j $((4*$(nproc)))
+	-j $(kernel_build_make_jobs)
 
 foldable end build_samples

--- a/build-selftests/action.yml
+++ b/build-selftests/action.yml
@@ -14,6 +14,9 @@ inputs:
   kbuild-output:
     description: 'relative or absolute path to use for storing build artifacts'
     default: '.'
+  max-make-jobs:
+    description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -22,3 +25,5 @@ runs:
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
         ${GITHUB_ACTION_PATH}/build_selftests.sh "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
+      env:
+        MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -38,7 +38,7 @@ make \
 	VMLINUX_BTF="${KBUILD_OUTPUT}/vmlinux" \
 	VMLINUX_H="${VMLINUX_H}" \
 	-C "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
-	-j $((4*$(nproc)))
+	-j $(kernel_build_make_jobs)
 cd -
 mkdir "${LIBBPF_PATH}"/selftests
 cp -R "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \

--- a/helpers.sh
+++ b/helpers.sh
@@ -56,3 +56,12 @@ llvm_version() {
     return 1
   fi
 }
+
+# No arguments
+kernel_build_make_jobs() {
+  # returns the number of processes to use when building kernel/selftests/samples
+  # default to 4*nproc if MAX_MAKE_JOBS is not defined
+  smp=$((4*$(nproc)))
+  MAX_MAKE_JOBS=${MAX_MAKE_JOBS:-$smp}
+  echo $(( smp > MAX_MAKE_JOBS ? MAX_MAKE_JOBS : smp ))
+}


### PR DESCRIPTION
Currently, the make jobs are spawn 4*nproc jobs. When running a single runner in a VM, that is fine, but when we have a physical machine running 10+ runners, we end up having 4k processes building at the same time.
This change will allow capping the number of jobs spawned by make to something reasonable for both the 1 runner per VM use case and the multiple runners per host use case.