### PR TITLE
Remove deprecated options and other transitory functionality

### DIFF
--- a/build-samples/action.yml
+++ b/build-samples/action.yml
@@ -1,10 +1,6 @@
 name: 'build samples/bpf'
 description: 'Build samples/bpf'
 inputs:
-  # TODO: Unused, remove once no client is providing it anymore.
-  vmlinux_btf:
-    description: 'path to vmlinux BTF file'
-    default: ''
   kernel:
     description: 'kernel version'
     default: 'LATEST'

--- a/build-selftests/action.yml
+++ b/build-selftests/action.yml
@@ -1,10 +1,6 @@
 name: 'build selftests'
 description: 'Build BPF selftests'
 inputs:
-  # TODO: Unused, remove once no client is providing it anymore.
-  vmlinux_btf:
-    description: 'path to vmlinux BTF file'
-    default: ''
   kernel:
     description: 'kernel version'
     default: 'LATEST'

--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -35,10 +35,7 @@ runs:
         export REPO_ROOT="${{ github.workspace }}"
         export KERNEL="${{ inputs.kernel }}"
         export KERNEL_ROOT="${{ inputs.kernel-root }}"
-        kbuild_output="${{ inputs.kbuild-output }}"
-        # TODO: Stop falling back to $KERNEL_ROOT once all clients provide this
-        #       input parameter.
-        kbuild_output="$(realpath $([ -z "$kbuild_output" ] && echo "$KERNEL_ROOT" || echo "$kbuild_output" ))"
+        kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
         $GITHUB_ACTION_PATH/run_vmtest.sh "${kbuild_output}" ${{ inputs.image-output }} ${{ inputs.test }}
       shell: bash
       env:

--- a/prepare-rootfs/run.sh
+++ b/prepare-rootfs/run.sh
@@ -107,7 +107,7 @@ while true; do
 			KERNELRELEASE="$2"
 			shift 2
 			;;
-	        --source)
+		--source)
 			KERNELSRC="$2"
 			shift 2
 			;;


### PR DESCRIPTION
With https://github.com/libbpf/libbpf/pull/610 and https://github.com/kernel-patches/vmtest/pull/164 merged all clients of the actions provided by this repository provide the now necessary `kbuild_output` argument and none is using `vmlinux_btf` anymore.

Signed-off-by: Daniel Müller <deso@posteo.net>