### PR TITLE
Allow passing the tests to run as an argument to qemu

### DIFF
--- a/run-qemu/action.yml
+++ b/run-qemu/action.yml
@@ -16,6 +16,9 @@ inputs:
   max-cpu:
     description: 'Maximum number of CPU allocated to a VM (regardless of number of CPUs available on the host). Default is unset, e.g it will default to the number of CPU on the host.'
     default: ''
+  kernel-test:
+    description: 'Test to run'
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -33,5 +36,6 @@ runs:
         IMG: ${{ inputs.img }}
         KERNEL_ROOT: ${{ inputs.kernel-root }}
         MAX_CPU: ${{ inputs.max-cpu }}
+        KERNEL_TEST: ${{ inputs.kernel-test }}
       run: |
         ARCH="${{ inputs.arch }}" ${GITHUB_ACTION_PATH}/run.sh

--- a/run-qemu/run.sh
+++ b/run-qemu/run.sh
@@ -73,6 +73,10 @@ fi
 
 smp=$(( $smp > $MAX_CPU ? $MAX_CPU : $smp ))
 
+if [[ -n ${KERNEL_TEST} ]]; then
+	APPEND+=" run_tests=${KERNEL_TEST}"
+fi
+
 "$qemu" -nodefaults --no-reboot -nographic \
   -chardev stdio,id=char0,mux=on,signal=off,logfile=boot.log \
   -serial chardev:char0 \

--- a/run-qemu/run.sh
+++ b/run-qemu/run.sh
@@ -77,11 +77,17 @@ if [[ -n ${KERNEL_TEST} ]]; then
 	APPEND+=" run_tests=${KERNEL_TEST}"
 fi
 
+CACHE_OPT=",cache=none"
+img_fs=$(df --output=fstype "${IMG}" | sed 1d)
+if [[ ${img_fs} == "tmpfs" ]]; then
+	CACHE_OPT=""
+fi
+
 "$qemu" -nodefaults --no-reboot -nographic \
   -chardev stdio,id=char0,mux=on,signal=off,logfile=boot.log \
   -serial chardev:char0 \
   ${accel} -smp "$smp" -m 8G \
-  -drive file="$IMG",format=raw,index=1,media=disk,if=virtio,cache=none \
+  -drive file="$IMG",format=raw,index=1,media=disk,if=virtio${CACHE_OPT} \
   -kernel "$VMLINUZ" -append "root=/dev/vda rw console=$console panic=-1 sysctl.vm.panic_on_oom=1 $APPEND"
 
 exitfile="${bpftool_exitstatus}\n"


### PR DESCRIPTION
Historically, we build a VM for each individual tests we wanted to run. At the end of the day, all tests are available within the VM and it is just a matter of what we did put in our init script.
With kernel-patches/vmtest#139 we can now pass the test to run as a command line argument at boot time. So, the run-qemu step will need to provide that test name.

tested with an unmodified kernel-patches/vmtest: https://github.com/kernel-patches/vmtest/pull/171/checks
and a modified one (e.g building the rootfs vm after building the kernel and providing the test on the boot command):  https://github.com/kernel-patches/vmtest/actions/runs/3432974206/jobs/5723083313