### PR TITLE
ansible: Prevent qemu-user-static from being reloaded on runner restart

### DIFF
--- a/ansible/roles/qemu-user-static/tasks/main.yml
+++ b/ansible/roles/qemu-user-static/tasks/main.yml
@@ -9,6 +9,7 @@
 
       [Service]
       Type=oneshot
+      RemainAfterExit=yes
       # The source code for iiilinuxibmcom/qemu-user-static is at https://github.com/iii-i/qemu-user-static/tree/v6.1.0-1
       # TODO: replace it with multiarch/qemu-user-static once version >6.1 is available
       ExecStart=/usr/bin/docker run --rm --interactive --privileged iiilinuxibmcom/qemu-user-static --reset -p yes


### PR DESCRIPTION
We need qemu-user-static.service to be started once to set up binfmt... Currently, this is set as a "oneshot" service, which runs and then is done.
The problem is that we have a dependency from the runners to `qemu-user-static`. When the runner restarts, `qemu-user-static` is not "active" (but "inactive/dead" instead), so it starts it. Because we use `--reset` in `qemu-user-static`, there is a time window when binaries from a foreign architecture won't be handled properly. Possibly in the middle of a runner run.
This change adds `RemainAfterExit=yes` to `qemu-user-static`, which has the effect of keeping the unit as "active" so it does not restart it.

This was tried on `bpf-ci-runner-s390x-5` and could confirm that when a runner restarted, the `qemu-user-static` service was not restarted.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>