### PR TITLE
Make kbuild-output input required in all actions

### DIFF
--- a/build-linux/action.yml
+++ b/build-linux/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 'gcc'
   kbuild-output:
     description: 'relative or absolute path to use for storing build artifacts'
-    default: '.'
+    required: true
   max-make-jobs:
     description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
     default: ''

--- a/build-samples/action.yml
+++ b/build-samples/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 'gcc'
   kbuild-output:
     description: 'relative or absolute path to use for storing build artifacts'
-    default: '.'
+    required: true
   max-make-jobs:
     description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
     default: ''

--- a/build-selftests/action.yml
+++ b/build-selftests/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 'gcc'
   kbuild-output:
     description: 'relative or absolute path to use for storing build artifacts'
-    default: '.'
+    required: true
   max-make-jobs:
     description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
     default: ''

--- a/prepare-rootfs/action.yml
+++ b/prepare-rootfs/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: true
   kbuild-output:
     description: 'relative or absolute path to use for storing build artifacts'
-    default: ''
+    required: true
   image-output:
     description: 'path where to store the generated image'
     required: true


### PR DESCRIPTION
At this point, there is no reason to build without KBUILD_OUTPUT specified: maintaining additional code paths that build that way is just a burden and there is no benefit of building within the source tree versus outside of it.
Hence, this change proposes making the kbuild-output argument to the various actions mandatory. It's already provided by all clients, so there is no effective change.

Signed-off-by: Daniel Müller <deso@posteo.net>