### PR TITLE
Interpret `diff(1)` exit code correctly

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -34,10 +34,10 @@ if [ -f "${KBUILD_OUTPUT}"/.config ]; then
 	KBUILD_OUTPUT="${kbuild_tmp}" make olddefconfig
 
 	if diff -q "${kbuild_tmp}"/.config "${KBUILD_OUTPUT}"/.config > /dev/null; then
+		echo "Existing kernel configuration is up-to-date"
+	else
 		echo "Using updated kernel configuration"
 		mv "${kbuild_tmp}"/.config "${KBUILD_OUTPUT}"/.config
-	else
-		echo "Existing kernel configuration is up-to-date"
 	fi
 	rm -rf "${kbuild_tmp}"
 else


### PR DESCRIPTION
`diff(1)` exits with 0 if two files are equal and 1 if they are not. That means our conditional logic is inverse of what it should be. Make sure to always update the config we use by swapping the branches.

Signed-off-by: Daniel Müller <deso@posteo.net>