### PR TITLE
Print diff when updating kernel config to use

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -36,7 +36,9 @@ if [ -f "${KBUILD_OUTPUT}"/.config ]; then
 	if diff -q "${kbuild_tmp}"/.config "${KBUILD_OUTPUT}"/.config > /dev/null; then
 		echo "Existing kernel configuration is up-to-date"
 	else
-		echo "Using updated kernel configuration"
+		echo "Using updated kernel configuration; diff:"
+		diff -u "${KBUILD_OUTPUT}"/.config "${kbuild_tmp}"/.config && :
+
 		mv "${kbuild_tmp}"/.config "${KBUILD_OUTPUT}"/.config
 	fi
 	rm -rf "${kbuild_tmp}"


### PR DESCRIPTION
The `build-linux` action conditionally updates the kernel config to use if it changed. It's generally useful to be able to see what exactly has changed. For example, the (expanded) configuration contains the compiler version and given that we install the newest clang snapshot on each run we may end up with a new compiler version compared to the one that created the build artifacts and  that forces a full rebuild. It's generally non-obvious when that happens and so printing a diff of the two configs can help better understand behavior, should the need arise.

Signed-off-by: Daniel Müller <deso@posteo.net>