### PR TITLE
[ansible][ci] Disable runner auto-update

### DIFF
--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -95,6 +95,7 @@
       ORG_NAME={{ item.0.name }}
       {% endif %}
       RUNNER_NAME={{ runner_name_prefix }}-{{ 'worker-%02d' | format(item.1) }}
+      DISABLE_AUTO_UPDATE=true
   loop: "{{ runners | subelements('workers') }}"
 
 - name: Docker GHCR login


### PR DESCRIPTION
When the containers try to auto-update, they need to restart, which cause them to come back on the old version. If the server instruct the runner to update again, we can end up in continuously restarting the runner without doing any meaningful work.

Our runners are being updated by a separate job [0] which produce a new container nightly and eventually pick up the update, so we don't really need the auto-update feature.

[0] https://github.com/kernel-patches/runner