### PR TITLE
Upgrade default llvm version to version 17

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -39,7 +39,7 @@ print_notice() {
 
 # No arguments
 llvm_default_version() {
-  echo "16"
+  echo "17"
 }
 
 # $1 - toolchain name


### PR DESCRIPTION
Currently, bpf CI is unable to locate llvm-16 on
aarch64/gcc, aarch64/llvm-16, and s390x/gcc [0].

This change upgrades the default llvm version to 17.

[0] https://github.com/kernel-patches/bpf/actions/runs/4040302668

Signed-off by: Joanne Koong <joannekoong@gmail.com>