### PR TITLE
rootfs: Upgrade to Debian Bookworm

### DIFF
--- a/rootfs/mkrootfs_debian.sh
+++ b/rootfs/mkrootfs_debian.sh
@@ -15,7 +15,7 @@ set -e -u -o pipefail
 CPUTABLE="${CPUTABLE:-/usr/share/dpkg/cputable}"
 
 deb_arch=$(dpkg --print-architecture)
-distro="bullseye"
+distro="bookworm"
 
 function usage() {
     echo "Usage: $0 [-a | --arch architecture] [-h | --help]


### PR DESCRIPTION
vmtest.sh fails on new distros with:

    ./test_progs: /lib/s390x-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./test_progs)

Upgrade the guest OS to handle new glibcs.

---

If this change is merged, could someone please run
```
sudo ./mkrootfs_debian.sh --arch=arm64
sudo ./mkrootfs_debian.sh --arch=s390x
```
and update https://github.com/libbpf/ci/blob/master/INDEX?
I tested this locally, but I do not have access to S3.