### PR TITLE
[s390x] Use `aptman/qus` instead of `multiarch/qemu-user-static`

### DIFF
--- a/ansible/roles/qemu-user-static/tasks/main.yml
+++ b/ansible/roles/qemu-user-static/tasks/main.yml
@@ -10,9 +10,11 @@
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      # The source code for iiilinuxibmcom/qemu-user-static is at https://github.com/iii-i/qemu-user-static/tree/v6.1.0-1
-      # TODO: replace it with multiarch/qemu-user-static once version >6.1 is available
-      ExecStart=/usr/bin/docker run --rm --interactive --privileged iiilinuxibmcom/qemu-user-static --reset -p yes
+      # https://github.com/multiarch/qemu-user-static does not support host arch != x86_64
+      # see https://github.com/multiarch/qemu-user-static/issues/174
+      # In the meantime use https://dbhi.github.io/qus/
+      ExecStartPre=/usr/bin/docker run --rm --interactive --privileged aptman/qus -s -- -r
+      ExecStart=/usr/bin/docker run --rm --interactive --privileged aptman/qus -s -- -p
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
`multiarch/qemu-user-static` does not support hosts other than x86_64.
`aptman/qus` does. The command syntax is slightly different though.

This change update the systemd resource to:
- [reset](https://github.com/dbhi/qus#reset) the registered format first.
- load all possible architectures persistently

To test, I confirmed that after using this new container, we could still run x86_64 containers in s390x hosts:

Before:
```
linux1@bpf-ci-runner-s390x-2:~$ sudo docker exec -ti 112b682130e9 bash
root@112b682130e9:/actions-runner# /usr/x86_64-linux-gnu/bin/ls
_diag  bin  config.sh  env.sh  externals  run-helper.cmd.template
run-helper.sh.template  run.sh  safe_sleep.sh  svc.sh
```

Updated systemd resource and restarted it:
```
linux1@bpf-ci-runner-s390x-2:~$ sudo systemctl status
qemu-user-static.service
● qemu-user-static.service - Support for transparent execution of
non-native binaries with QEMU user emulation
     Loaded: loaded (/etc/systemd/system/qemu-user-static.service;
enabled; vendor preset: enabled)
     Active: active (exited) since Mon 2023-02-06 21:47:14 UTC; 7s ago
    Process: 2761053 ExecStartPre=/usr/bin/docker run --rm --interactive
--privileged aptman/qus -s -- -r (code=exited, status=0/SUCCESS)
    Process: 2761265 ExecStart=/usr/bin/docker run --rm --interactive
--privileged aptman/qus -s -- -p (code=exited, status=0/SUCCESS)
   Main PID: 2761265 (code=exited, status=0/SUCCESS)

Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-riscv32-static as binfmt interpreter for riscv32
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-riscv64-static as binfmt interpreter for riscv64
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-xtensa-static as binfmt interpreter for xtensa
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-xtensaeb-static as binfmt interpreter for xtensaeb
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-microblaze-static as binfmt interpreter for microblaze
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-microblazeel-static as binfmt interpreter for microblazeel
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-or1k-static as binfmt interpreter for or1k
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-x86_64-static as binfmt interpreter for x86_64
Feb 06 21:47:12 bpf-ci-runner-s390x-2 docker[2761265]: Setting
/qus/bin/qemu-hexagon-static as binfmt interpreter for hexagon
Feb 06 21:47:14 bpf-ci-runner-s390x-2 systemd[1]: Finished Support for
transparent execution of non-native binaries with QEMU user emulation.
linux1@bpf-ci-runner-s390x-2:~$ sudo docker exec -ti 112b682130e9 bash
root@112b682130e9:/actions-runner# /usr/x86_64-linux-gnu/bin/ls
_diag  bin  config.sh  env.sh  externals  run-helper.cmd.template
run-helper.sh.template  run.sh  safe_sleep.sh  svc.sh
```

Signed-off-by: Manu Bretelle <chantr4@gmail.com>