### PR TITLE
default to llvm 16

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -39,6 +39,11 @@ print_notice() {
 
 # No arguments
 llvm_default_version() {
+  echo "16"
+}
+
+# No arguments
+llvm_latest_version() {
   echo "17"
 }
 

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -10,7 +10,14 @@ sudo apt-get install -y g++ libelf-dev
 
 LLVM_VERSION=$(llvm_default_version)
 
-echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" | sudo tee /etc/apt/sources.list.d/llvm.list
+REPO_DISTRO_SUFFIX="-${LLVM_VERSION}"
+
+if [[ "${LLVM_VERSION}" == $(llvm_latest_version) ]]
+then
+    REPO_DISTRO_SUFFIX=""
+fi
+
+echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal${REPO_DISTRO_SUFFIX} main" | sudo tee /etc/apt/sources.list.d/llvm.list
 n=0
 while [ $n -lt 5 ]; do
   set +e && \


### PR DESCRIPTION
This change get us back onto llvm-16 by default as it seemsthat currently, qemu VMs are failing to boot when the kernel is built with llvm 17, it is very likely related to
https://github.com/ClangBuiltLinux/linux/issues/1800 .

Because of the layout of LLVM's apt repo, unless the version is the latest they distribute, the repository distro need to use the version number as suffix.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>