### PR TITLE
[build_pahole] Use PAHOLE_{BRANCH,ORIGIN} from env, or set to defaults

### DIFF
--- a/setup-build-env/build_pahole.sh
+++ b/setup-build-env/build_pahole.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+PAHOLE_BRANCH=${PAHOLE_BRANCH:-master}
+PAHOLE_ORIGIN=${PAHOLE_ORIGIN:-https://git.kernel.org/pub/scm/devel/pahole/pahole.git}
+
 source $(cd $(dirname $0) && pwd)/../helpers.sh
 
 foldable start build_pahole "Building pahole"
@@ -9,14 +12,13 @@ foldable start build_pahole "Building pahole"
 sudo apt-get update && sudo apt-get install elfutils libelf-dev libdw-dev
 
 CWD=$(pwd)
-PAHOLE_ORIGIN=https://git.kernel.org/pub/scm/devel/pahole/pahole.git
 
 mkdir -p pahole
 cd pahole
 git init
 git remote add origin ${PAHOLE_ORIGIN}
-git fetch --depth=1 origin
-git checkout master
+git fetch --depth=1 origin "${PAHOLE_BRANCH}"
+git checkout "${PAHOLE_BRANCH}"
 
 mkdir -p build
 cd build


### PR DESCRIPTION
The action has those 2 env var documented, but they were either not used, or statically set in the script. Fix it, this way we can set custom repo/revision when invoking the action.

Testing:

Ran a kernel-patches/bpf test against this branch with the action variable set to
```
pahole: b53d430aeab416e74dd394d646a9e9b21dc7a324
```

which resulted in the following logs.

```
Run export PAHOLE_BRANCH=b53d430aeab416e74dd394d646a9e9b21dc7a324
  export PAHOLE_BRANCH=b53d430aeab416e74dd394d646a9e9b21dc7a324
  export PAHOLE_ORIGIN=https://git.kernel.org/pub/scm/devel/pahole/pahole.git
  ${GITHUB_ACTION_PATH}/build_pahole.sh
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    KERNEL: LATEST
    REPO_ROOT: /tmp/work/bpf/bpf
    REPO_PATH:
    KBUILD_OUTPUT: kbuild-output/
build_pahole - Building pahole
  Hit:1 https://download.docker.com/linux/ubuntu focal InRelease
  Hit:2 https://apt.llvm.org/focal llvm-toolchain-focal-16 InRelease
  Hit:3 http://security.ubuntu.com/ubuntu focal-security InRelease
  Hit:4 http://ppa.launchpad.net/git-core/ppa/ubuntu focal InRelease
  Hit:5 http://archive.ubuntu.com/ubuntu focal InRelease
  Hit:6 http://archive.ubuntu.com/ubuntu focal-updates InRelease
  Hit:7 http://archive.ubuntu.com/ubuntu focal-backports InRelease
  Get:8 https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04  InRelease [1,642 B]
  Fetched 1,642 B in 1s (2,287 B/s)
  Reading package lists...
  Reading package lists...
  Building dependency tree...
  Reading state information...
  elfutils is already the newest version (0.176-1.1build1).
  libdw-dev is already the newest version (0.176-1.1build1).
  libelf-dev is already the newest version (0.176-1.1build1).
  0 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
  hint: Using 'master' as the name for the initial branch. This default branch name
  hint: is subject to change. To configure the initial branch name to use in all
  hint: of your new repositories, which will suppress this warning, call:
  hint:
  hint: 	git config --global init.defaultBranch <name>
  hint:
  hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
  hint: 'development'. The just-created branch can be renamed via this command:
  hint:
  hint: 	git branch -m <name>
  Initialized empty Git repository in /tmp/work/bpf/bpf/pahole/.git/
  From https://git.kernel.org/pub/scm/devel/pahole/pahole
   * branch            b53d430aeab416e74dd394d646a9e9b21dc7a324 -> FETCH_HEAD
  Note: switching to 'b53d430aeab416e74dd394d646a9e9b21dc7a324'.

  You are in 'detached HEAD' state. You can look around, make experimental
  changes and commit them, and you can discard any commits you make in this
  state without impacting any branches by switching back to a branch.

  If you want to create a new branch to retain commits you create, you may
  do so (now or later) by using -c with the switch command. Example:

    git switch -c <new-branch-name>

  Or undo this operation with:

    git switch -

  Turn off this advice by setting config variable advice.detachedHead to false
```

Also confirmed that having the branch set to `master` worked.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>