### PR TITLE
default to llvm 17

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -39,7 +39,7 @@ print_notice() {
 
 # No arguments
 llvm_default_version() {
-  echo "16"
+  echo "17"
 }
 
 # No arguments


### PR DESCRIPTION
llvm 16 issues seems fixed and using llvm 16 as the default caused arm64 and s390x failure with the following error message:

  The following packages have unmet dependencies:
   clang-16 : Depends: libclang-common-16-dev (= 1:16.0.0~++20230222063320+4c0da2726e7f-1~exp1~20230222063432.36) but it is not going to be installed
  E: Unable to correct problems, you have held broken packages.
  clang install failed
  Error: Process completed with exit code 1.

let us move to llvm 17.