### PR TITLE
Add inputs.llvm-version

### DIFF
--- a/build-linux/action.yml
+++ b/build-linux/action.yml
@@ -13,6 +13,10 @@ inputs:
   max-make-jobs:
     description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
     default: ''
+  llvm-version:
+    description: 'llvm version'
+    required: false
+    default: '16'
 runs:
   using: "composite"
   steps:
@@ -20,6 +24,7 @@ runs:
       shell: bash
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
+        export LLVM_VERSION=${{ inputs.llvm-version }}
         ${GITHUB_ACTION_PATH}/build.sh "${{ inputs.arch }}" "${{ inputs.toolchain }}" "${kbuild_output}"
       env:
         MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -10,9 +10,9 @@ ARCH="$1"
 TOOLCHAIN="$2"
 export KBUILD_OUTPUT="$3"
 
-LLVM_VER="$(llvm_version $TOOLCHAIN)" && :
-if [ $? -eq 0 ]; then
-	export LLVM="-$LLVM_VER"
+if [ $TOOLCHAIN = "llvm" ]; then
+	export LLVM="-$LLVM_VERSION"
+	TOOLCHAIN="llvm-$LLVM_VERSION"
 fi
 
 foldable start build_kernel "Building kernel with $TOOLCHAIN"

--- a/build-samples/action.yml
+++ b/build-samples/action.yml
@@ -13,6 +13,10 @@ inputs:
   max-make-jobs:
     description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
     default: ''
+  llvm-version:
+    description: 'llvm version'
+    required: false
+    default: '16'
 
 runs:
   using: "composite"
@@ -21,6 +25,7 @@ runs:
       shell: bash
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
+        export LLVM_VERSION=${{ inputs.llvm-version }}
         ${GITHUB_ACTION_PATH}/build_samples.sh "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
       env:
         MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-samples/build_samples.sh
+++ b/build-samples/build_samples.sh
@@ -10,9 +10,9 @@ KERNEL="$1"
 TOOLCHAIN="$2"
 export KBUILD_OUTPUT="$3"
 
-LLVM_VER="$(llvm_version $TOOLCHAIN)" && :
-if [ $? -eq 0 ]; then
-	export LLVM="-$LLVM_VER"
+if [ $TOOLCHAIN = "llvm" ]; then
+	export LLVM="-$LLVM_VERSION"
+	TOOLCHAIN="llvm-$LLVM_VERSION"
 fi
 
 foldable start build_samples "Building samples with $TOOLCHAIN"
@@ -25,13 +25,13 @@ fi
 
 make headers_install
 make \
-	CLANG=clang-${LLVM_VER} \
-	OPT=opt-${LLVM_VER} \
-	LLC=llc-${LLVM_VER} \
-	LLVM_DIS=llvm-dis-${LLVM_VER} \
-	LLVM_OBJCOPY=llvm-objcopy-${LLVM_VER} \
-	LLVM_READELF=llvm-readelf-${LLVM_VER} \
-	LLVM_STRIP=llvm-strip-${LLVM_VER} \
+	CLANG=clang-${LLVM_VERSION} \
+	OPT=opt-${LLVM_VERSION} \
+	LLC=llc-${LLVM_VERSION} \
+	LLVM_DIS=llvm-dis-${LLVM_VERSION} \
+	LLVM_OBJCOPY=llvm-objcopy-${LLVM_VERSION} \
+	LLVM_READELF=llvm-readelf-${LLVM_VERSION} \
+	LLVM_STRIP=llvm-strip-${LLVM_VERSION} \
 	VMLINUX_BTF="${KBUILD_OUTPUT}/vmlinux" \
 	VMLINUX_H="${VMLINUX_H}" \
 	-C "${REPO_ROOT}/${REPO_PATH}/samples/bpf" \

--- a/build-selftests/action.yml
+++ b/build-selftests/action.yml
@@ -13,6 +13,10 @@ inputs:
   max-make-jobs:
     description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
     default: ''
+  llvm-version:
+    description: 'llvm version'
+    required: false
+    default: '16'
 runs:
   using: "composite"
   steps:
@@ -20,6 +24,7 @@ runs:
       shell: bash
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
+        export LLVM_VERSION=${{ inputs.llvm-version }}
         ${GITHUB_ACTION_PATH}/build_selftests.sh "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
       env:
         MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -10,9 +10,9 @@ KERNEL="$1"
 TOOLCHAIN="$2"
 export KBUILD_OUTPUT="$3"
 
-LLVM_VER="$(llvm_version $TOOLCHAIN)" && :
-if [ $? -eq 0 ]; then
-	export LLVM="-$LLVM_VER"
+if [[ $TOOLCHAIN = "llvm" ]]; then
+	export LLVM="-$LLVM_VERSION"
+	TOOLCHAIN="llvm-$LLVM_VERSION"
 fi
 
 foldable start build_selftests "Building selftests with $TOOLCHAIN"
@@ -32,9 +32,9 @@ fi
 
 cd ${REPO_ROOT}/${REPO_PATH}
 make \
-	CLANG=clang-${LLVM_VER} \
-	LLC=llc-${LLVM_VER} \
-	LLVM_STRIP=llvm-strip-${LLVM_VER} \
+	CLANG=clang-${LLVM_VERSION} \
+	LLC=llc-${LLVM_VERSION} \
+	LLVM_STRIP=llvm-strip-${LLVM_VERSION} \
 	VMLINUX_BTF="${KBUILD_OUTPUT}/vmlinux" \
 	VMLINUX_H="${VMLINUX_H}" \
 	-C "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \

--- a/helpers.sh
+++ b/helpers.sh
@@ -47,21 +47,6 @@ llvm_latest_version() {
   echo "17"
 }
 
-# $1 - toolchain name
-llvm_version() {
-  local toolchain="$1"
-  local toolchain_name="$(echo $toolchain | cut -d '-' -f 1)"
-  local toolchain_version="$(echo $toolchain | cut -d '-' -f 2)"
-
-  if [ "$toolchain_name" == "llvm" ]; then
-    echo "$toolchain_version"
-    return 0
-  else
-    llvm_default_version
-    return 1
-  fi
-}
-
 # No arguments
 kernel_build_make_jobs() {
   # returns the number of processes to use when building kernel/selftests/samples

--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'pahole repo'
     required: true
     default: 'https://git.kernel.org/pub/scm/devel/pahole/pahole.git'
+  llvm-version:
+    description: 'llvm version'
+    required: false
+    default: '16'
 runs:
   using: "composite"
   steps:
@@ -22,6 +26,7 @@ runs:
     - name: Install clang
       shell: bash
       run: |
+        export LLVM_VERSION=${{ inputs.llvm-version }}
         ${GITHUB_ACTION_PATH}/install_clang.sh
     - name: Install pahole
       shell: bash

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -8,13 +8,10 @@ foldable start install_clang "Installing Clang/LLVM"
 sudo apt-get update
 sudo apt-get install -y g++ libelf-dev
 
-LLVM_VERSION=$(llvm_default_version)
-
-REPO_DISTRO_SUFFIX="-${LLVM_VERSION}"
-
-if [[ "${LLVM_VERSION}" == $(llvm_latest_version) ]]
-then
+if [[ "${LLVM_VERSION}" == $(llvm_latest_version) ]] ; then
     REPO_DISTRO_SUFFIX=""
+else
+    REPO_DISTRO_SUFFIX="-${LLVM_VERSION}"
 fi
 
 echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal${REPO_DISTRO_SUFFIX} main" | sudo tee /etc/apt/sources.list.d/llvm.list


### PR DESCRIPTION
Since we always build BPF programs with clang, ci also installs llvm when inputs.toolchain is gcc. llvm_version(). Instead of parsing llvm version from inputs.toolchain, add a separate input field of llvm-version.