### PR TITLE
[run-qemu] consume test_progs json report

### DIFF
--- a/run-qemu/run.sh
+++ b/run-qemu/run.sh
@@ -104,6 +104,46 @@ fi
 
 foldable end shutdown
 
+# Try to collect json summary from VM
+if [[ -n ${KERNEL_TEST} && ${KERNEL_TEST} =~ test_progs* ]]
+then
+    guestfish --ro -a "$IMG" -i download "/${KERNEL_TEST}.json" "${KERNEL_TEST}.json"
+    if [ $? ]
+    then
+        ## Job summary
+        echo "# Tests summary" >> "${GITHUB_STEP_SUMMARY}"
+        read -r T_SUCCESS T_SUCCESS_SUBTEST T_SKIPPED T_FAILED < \
+            <(jq -r < "${KERNEL_TEST}.json" '"\(.success) \(.success_subtest) \(.skipped) \(.failed)"')
+        echo "- :heavy_check_mark: Success: ${T_SUCCESS}/${T_SUCCESS_SUBTEST}
+- :next_track_button: Skipped: ${T_SKIPPED}
+- :x: Failed: ${T_FAILED}" >> "${GITHUB_STEP_SUMMARY}"
+
+        summary_annotation="Success: ${T_SUCCESS}/${T_SUCCESS_SUBTEST}, Skipped: ${T_SKIPPED}, Failed: ${T_FAILED}"
+        echo "::notice::${summary_annotation}"
+
+        # Print failed tests to summary/annotations
+        if [ "${T_FAILED}" -gt 0 ]
+        then
+            echo "# Failed tests" >> "${GITHUB_STEP_SUMMARY}"
+            jq -r < "${KERNEL_TEST}.json" \
+                '.results | map([
+                    if .failed then "#\(.number) \(.name)" else empty end,
+                    (
+                        . as {name: $tname, number: $tnum} | .subtests | map(
+                            if .failed then "#\($tnum)/\(.number) \($tname)/\(.name)" else empty end
+                        )
+                    )
+                ]) | flatten | .[]' | \
+                while read -r line
+                do
+                    # Job summary
+                    echo "${line}" >> "${GITHUB_STEP_SUMMARY}"
+                    # Annotations
+                    echo "::error::${line}"
+                done
+        fi
+    fi
+fi
 # Final summary - Don't use a fold, keep it visible
 echo -e "\033[1;33mTest Results:\033[0m"
 echo -e "$exitfile" | while read result; do


### PR DESCRIPTION
This change makes the qemu action consume the report generated by test_progs (introduced in kernel-patches/vmtest#207) and generates github annotations [0] of the summary as well as the failing tests. It also generates a summary of the job [1].

The end goal is to provide an easier way for people to directly access the tests that failed instead of having to scroll through pages of logs.

[0] https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
[1] https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary