### PR TITLE
[run-qemu] Add 'output_dir' action parameter

### DIFF
--- a/run-qemu/action.yml
+++ b/run-qemu/action.yml
@@ -19,6 +19,11 @@ inputs:
   kernel-test:
     description: 'Test to run'
     default: ''
+  output-dir:
+    description: |
+      Some sub-commands produce output dir within VM file system (/command_output/).
+      If this option is set that dir's content would be copied to corresponding location.
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -37,5 +42,6 @@ runs:
         KERNEL_ROOT: ${{ inputs.kernel-root }}
         MAX_CPU: ${{ inputs.max-cpu }}
         KERNEL_TEST: ${{ inputs.kernel-test }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
       run: |
         ARCH="${{ inputs.arch }}" ${GITHUB_ACTION_PATH}/run.sh

--- a/run-qemu/run.sh
+++ b/run-qemu/run.sh
@@ -114,6 +114,15 @@ then
         "${GITHUB_ACTION_PATH}/print_test_summary.py" -s "${GITHUB_STEP_SUMMARY}" -j "${KERNEL_TEST}.json"
     fi
 fi
+
+# Try to collect $IMG:/command_output to OUTPUT_DIR
+if [[ -n "${OUTPUT_DIR}" ]]
+then
+    mkdir -p "${OUTPUT_DIR}"
+    guestfish --ro --add "$IMG" --inspector tar-out /command_output/ - \
+        | tar --extract --file - --directory="${OUTPUT_DIR}"
+fi
+
 # Final summary - Don't use a fold, keep it visible
 echo -e "\033[1;33mTest Results:\033[0m"
 echo -e "$exitfile" | while read result; do


### PR DESCRIPTION
Add capability to extract contents of /command_output/ directory from the qemu disk image after qemu execution. This is useful when there is a need to extract multiple result files after tests run.

To use this specify the `output-dir` parameter for the action, e.g.:

```yaml
      - name: Run veristat
        uses: eddyz87/libbpf-ci/run-qemu@main
        timeout-minutes: 10
        with:
          arch: x86_64
          img: '/tmp/root.img'
          vmlinuz: '${{ github.workspace }}/vmlinuz'
          kernel-root: '.'
          max-cpu: 8
          kernel-test: run_veristat
          output-dir: '${{ github.workspace }}'   # <--- here
```