### PR TITLE
[build-selftests] Clean selftests before building them

### DIFF
--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -31,14 +31,19 @@ else
 fi
 
 cd ${REPO_ROOT}/${REPO_PATH}
-make \
-	CLANG=clang-${LLVM_VERSION} \
-	LLC=llc-${LLVM_VERSION} \
-	LLVM_STRIP=llvm-strip-${LLVM_VERSION} \
-	VMLINUX_BTF="${KBUILD_OUTPUT}/vmlinux" \
-	VMLINUX_H="${VMLINUX_H}" \
-	-C "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
-	-j $(kernel_build_make_jobs)
+
+MAKE_OPTS=$(cat <<EOF
+	CLANG=clang-${LLVM_VERSION}
+	LLC=llc-${LLVM_VERSION}
+	LLVM_STRIP=llvm-strip-${LLVM_VERSION}
+	VMLINUX_BTF=${KBUILD_OUTPUT}/vmlinux
+	VMLINUX_H=${VMLINUX_H}
+	-C ${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf
+EOF
+)
+make ${MAKE_OPTS} clean
+make ${MAKE_OPTS} -j $(kernel_build_make_jobs)
+
 cd -
 mkdir "${LIBBPF_PATH}"/selftests
 cp -R "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \


### PR DESCRIPTION
Cleaning selftests is useful in case if cached kernel build artifacts contain build results for selftests.
---
For the context:

I'm currently working on a BPI CI job that executes veristat tool for both push and pull_request events:
- for push in order to obtain baseline performance data;
- for pull_request in order to compare branch performance data with baseline performance data.

The veristat is built with selftests and uses some selftest .bpf.o binary files as an input.
Currently selftests are not built on push, but this would have to change.
Which means that cached incremental kernel build artifacts might now contain selftest binary files.
I'd like to add the clean action to selftests compilation to avoid any potential issues with stale selftest binary files when pull_request event is processed.