### PR TITLE
[ansible] force aptman/qus with tag d7.1

### DIFF
--- a/ansible/roles/qemu-user-static/defaults/main.yml
+++ b/ansible/roles/qemu-user-static/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+qus_container_name: aptman/qus
+qus_container_tag: d7.1

--- a/ansible/roles/qemu-user-static/tasks/main.yml
+++ b/ansible/roles/qemu-user-static/tasks/main.yml
@@ -13,8 +13,8 @@
       # https://github.com/multiarch/qemu-user-static does not support host arch != x86_64
       # see https://github.com/multiarch/qemu-user-static/issues/174
       # In the meantime use https://dbhi.github.io/qus/
-      ExecStartPre=/usr/bin/docker run --rm --interactive --privileged aptman/qus -s -- -r
-      ExecStart=/usr/bin/docker run --rm --interactive --privileged aptman/qus -s -- -p
+      ExecStartPre=/usr/bin/docker run --rm --interactive --privileged {{ qus_container_name }}:{{ qus_container_tag }} -s -- -r
+      ExecStart=/usr/bin/docker run --rm --interactive --privileged {{ qus_container_name }}:{{ qus_container_tag }} -s -- -p
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
We have had issue with the latest tag on newly provisioned s390x machines. More specifically some x86_64 command would fails while some other were not. The exact failure is yet TBD, but through troubleshooting and narrowing down the scope of the issue, it appears to have been a regression with the latest container version of aptman/qus, which is currently 7.2.
This pins the container to the debian version of the 7.1 release.

Test plan:
- run using version d7.1: https://github.com/chantra/gh_runner_tests/actions/runs/4802032141/attempts/5 (succeed)
- run using version d7.2: https://github.com/chantra/gh_runner_tests/actions/runs/4802032141/attempts/6 (failed)