### PR TITLE
[build-selftests] Run make headers before building selftests

### DIFF
--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -38,11 +38,15 @@ MAKE_OPTS=$(cat <<EOF
 	LLVM_STRIP=llvm-strip-${LLVM_VERSION}
 	VMLINUX_BTF=${KBUILD_OUTPUT}/vmlinux
 	VMLINUX_H=${VMLINUX_H}
+EOF
+)
+SELF_OPTS=$(cat <<EOF
 	-C ${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf
 EOF
 )
-make ${MAKE_OPTS} clean
-make ${MAKE_OPTS} -j $(kernel_build_make_jobs)
+make ${MAKE_OPTS} headers
+make ${MAKE_OPTS} ${SELF_OPTS} clean
+make ${MAKE_OPTS} ${SELF_OPTS} -j $(kernel_build_make_jobs)
 
 cd -
 mkdir "${LIBBPF_PATH}"/selftests


### PR DESCRIPTION
Fixes BPF CI selftest build after 9fc96c7c19df ("selftests: error out if kernel header files are not yet built").


Link: https://lore.kernel.org/lkml/11b94ce7-d7e3-1935-307b-5a0a0f32739f@collabora.com