### PR TITLE
rootfs: Support building Ubuntu rootfs

### DIFF
--- a/rootfs/mkrootfs_debian.sh
+++ b/rootfs/mkrootfs_debian.sh
@@ -156,6 +156,7 @@ packages=$(IFS=, && echo "${packages[*]}")
 
 # Stage 1
 debootstrap --include="$packages" \
+    --components=main,universe \
     --foreign \
     --variant=minbase \
     --arch="${deb_arch}" \


### PR DESCRIPTION
When building rootfs, we install `busybox`.
In Ubuntu, this is hosted under the `universe` component: https://packages.ubuntu.com/focal/busybox

We can specify which component to use with debootstrap. While Debian does not have a universe component, it handles it just fine so we do not need to special case Debian vs Ubuntu.

Test Plan:

Successfully built rootfs for focal and bullseye:

```
sudo ./mkrootfs_debian.sh  --distro bullseye
sudo ./mkrootfs_debian.sh  --distro focal
```