### PR TITLE
build-kernel: Add selftests/bpf/config.vm to the list of config files

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -20,6 +20,7 @@ foldable start build_kernel "Building kernel with $TOOLCHAIN"
 # $1 - path to config file to create/overwrite
 cat_kernel_config() {
 	cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config \
+	    ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.vm \
 	    ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.${ARCH} \
 	    ${GITHUB_WORKSPACE}/ci/vmtest/configs/config \
 	    ${GITHUB_WORKSPACE}/ci/vmtest/configs/config.${ARCH} 2> /dev/null > "${1}"


### PR DESCRIPTION
In preparation of landing v2 of https://lore.kernel.org/bpf/ZTxaRT8AXCNXYmRd@surya/T/#t

Include config.vm files, which in the future will include VM related kernel configs