### PR TITLE
ansible: Allow passing tmpfs options

### DIFF
--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -3,6 +3,8 @@ runner_base_dir: /etc/actions-runner
 runner_workers: 1
 runner_prefix: ""
 runner_workdir: /tmp/work
+runner_tmpfs_options:
+  - exec
 runner_gh_token_default: replace with your token
 runner_gh_user_default: replace with your GH user
 runner_docker_tag: main

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -142,7 +142,7 @@
       {% if runner_docker_mount_volume %}
                   --volume=actions-runner-{{ item.normalized }}-worker-%i:{{ runner_workdir }} \
       {% else %}
-                  {{ '--tmpfs %s:exec' | format(runner_workdir) }} \
+                  {{ '--tmpfs %s:%s' | format(runner_workdir, runner_tmpfs_options | join(',')) }} \
       {% endif %}
                   --rm \
                   --env-file "{{ runner_base_dir }}/actions-runner-{{ item.normalized }}-worker-%i.env" \


### PR DESCRIPTION
Currently, the only option passed to tmpfs is `exec` so tmpfs is mounted with "exec" option.
We may need to pass extra options on some runners, like setting the size of tmpfs for instance (docker seems to default to 50% of the host memory), and only on specific hosts, so we need this to be somwhat configurable.

Add a new variable `runner_tmpfs_options` which defaults to `['exec']` and can be overridden at the host/group level.

Test, after setting a host to use:
```
        runner_tmpfs_options:
          - exec
          - size=12G
```

running ansible in dry-run mode:
```
--- before: /etc/systemd/system/actions-runner-kernel-patches@.service
+++ after:
/home/chantra/.ansible/tmp/ansible-local-3819115bni8m1fy/tmp65ktafym
@@ -15,7 +15,7 @@
             --health-cmd='(ss -ntp -H dport = :443 | grep -q ESTAB) ||
exit 1' \
 --health-start-period=60s --health-interval=30s \
 --health-timeout=5s --health-retries=3 \
-            --tmpfs /tmp/work:exec \
+            --tmpfs /tmp/work:exec,size=12G \
             --rm \
             --env-file
"/etc/actions-runner/actions-runner-kernel-patches-worker-%i.env" \
             --env-file
"/etc/actions-runner/actions-runner-kernel-patches-worker-%i-ghtoken.env"
\

```

And for a hosts with no override, running ansible does not chasnge anything.