### PR TITLE
Debian-Gnu name lookup issue for ppc64el

### DIFF
--- a/rootfs/Makefile
+++ b/rootfs/Makefile
@@ -1,4 +1,4 @@
-ARCHS = amd64 arm64 s390x
+ARCHS = amd64 arm64 s390x ppc64el
 DISTROS = bullseye
 
 .PHONY: all

--- a/rootfs/mkrootfs_debian.sh
+++ b/rootfs/mkrootfs_debian.sh
@@ -44,6 +44,9 @@ function qemu_static() {
     # Given a Debian architecture find the location of the matching
     # qemu-${gnu_arch}-static binary.
     gnu_arch=$(debian_to_gnu "${1}")
+    if [ "$deb_arch" == "ppc64el" ]; then
+	    gnu_arch="ppc64le"
+    fi
     echo "qemu-${gnu_arch}-static"
 }
 


### PR DESCRIPTION
The usr/share/dpkg/cputable contains mapping ppc64el->powerpc64le, so mkrootfs_debian.sh does lookup with qemu-powerpc64le-static, which is incorrect.