### PR TITLE
ansible: Force urllib3 to version <2.0

### DIFF
--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -5,6 +5,8 @@
   become: yes
   ansible.builtin.pip:
     name:
+      # AL2 python's version is compiled against openssl 1.0, urllib3>=2.0 needs openssl 1.1.1
+      - urllib3<2.0
       - docker
     extra_args: --user
     executable: pip3


### PR DESCRIPTION
Amazon Linux 2 has python'ssl module built using openssl 1.0.X.

urllib3>=2.0 requires an ssl module built against openssl 1.1.1+

This change forces urllib3<2.0 so ansible can successfully run the GHCR login step, or would otherwise fail with:
```
TASK [runner : Docker GHCR login] **********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
fatal: [i-06ae916dc1d358725]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (requests) on ip-10-0-0-68.us-west-1.compute.internal's Python /usr/bin/python3.7. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```