### PR TITLE
helpers: update latest clang version to 19

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -44,7 +44,7 @@ llvm_default_version() {
 
 # No arguments
 llvm_latest_version() {
-  echo "18"
+  echo "19"
 }
 
 # No arguments


### PR DESCRIPTION
From https://apt.llvm.org/
> Jan 25th 2024 - Snapshot becomes 19, branch 18 created

Becuase of how the repositories are layed out, we need to update this value to latest be able to build the right repository URL.