### PR TITLE
ansible: Run qemu-static-user on all hosts

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -5,6 +5,5 @@
       tags: [base]
     - role: qemu-user-static
       tags: [qemu]
-      when: ansible_architecture == "s390x"
     - role: runner
       tags: [runner]


### PR DESCRIPTION
We used to only run this role on s390x (because it needs it to be able to run x86 actions-runner on s390x).
I am planning to also leverage this for some cross-compilation work where some step unfortunately need to be able to run a binary in the target format.

Test:
```
ansible-playbook -i ~/inventory.yml ./playbook.yml   --limit aws -t qemu
```