### PR TITLE
actions: Upgrade checkout action to v4

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         env:

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Test print_test_summary
         run: ./run-vmtest/print_test_summary.py  -j run-vmtest/fixtures/test_progs.json -s "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
v3 depends on nodejs16 which is being deprecated. Upgrade to v4.