### PR TITLE
cross-compilation: make libbpf/ci cross-compilation aware

### DIFF
--- a/build-samples/action.yml
+++ b/build-samples/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: 'llvm version'
     required: false
     default: '16'
+  arch:
+    description: 'arch'
+    required: true
 
 runs:
   using: "composite"
@@ -26,6 +29,6 @@ runs:
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
         export LLVM_VERSION=${{ inputs.llvm-version }}
-        ${GITHUB_ACTION_PATH}/build_samples.sh "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
+        ${GITHUB_ACTION_PATH}/build_samples.sh "${{ inputs.arch }}" "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
       env:
         MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-samples/build_samples.sh
+++ b/build-samples/build_samples.sh
@@ -6,9 +6,18 @@ THISDIR="$(cd $(dirname $0) && pwd)"
 
 source "${THISDIR}"/../helpers.sh
 
-KERNEL="$1"
-TOOLCHAIN="$2"
-export KBUILD_OUTPUT="$3"
+TARGET_ARCH="$1"
+KERNEL="$2"
+TOOLCHAIN="$3"
+export KBUILD_OUTPUT="$4"
+
+ARCH="$(platform_to_kernel_arch ${TARGET_ARCH})"
+CROSS_COMPILE=""
+
+if [[ "${TARGET_ARCH}" != "$(uname -m)" ]]
+then
+	CROSS_COMPILE="${TARGET_ARCH}-linux-gnu-"
+fi
 
 if [ $TOOLCHAIN = "llvm" ]; then
 	export LLVM="-$LLVM_VERSION"
@@ -25,6 +34,8 @@ fi
 
 make headers_install
 make \
+	ARCH="${ARCH}" \
+	CROSS_COMPILE="${CROSS_COMPILE}" \
 	CLANG=clang-${LLVM_VERSION} \
 	OPT=opt-${LLVM_VERSION} \
 	LLC=llc-${LLVM_VERSION} \

--- a/build-selftests/action.yml
+++ b/build-selftests/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'llvm version'
     required: false
     default: '16'
+  arch:
+    description: 'arch'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -25,6 +29,6 @@ runs:
       run: |
         kbuild_output="$(realpath ${{ inputs.kbuild-output }})"
         export LLVM_VERSION=${{ inputs.llvm-version }}
-        ${GITHUB_ACTION_PATH}/build_selftests.sh "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
+        ${GITHUB_ACTION_PATH}/build_selftests.sh "${{ inputs.arch }}" "${{ inputs.kernel }}" "${{ inputs.toolchain }}" "${kbuild_output}"
       env:
         MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}

--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -6,9 +6,18 @@ THISDIR="$(cd $(dirname $0) && pwd)"
 
 source "${THISDIR}"/../helpers.sh
 
-KERNEL="$1"
-TOOLCHAIN="$2"
-export KBUILD_OUTPUT="$3"
+TARGET_ARCH="$1"
+KERNEL="$2"
+TOOLCHAIN="$3"
+export KBUILD_OUTPUT="$4"
+
+ARCH="$(platform_to_kernel_arch ${TARGET_ARCH})"
+CROSS_COMPILE=""
+
+if [[ "${TARGET_ARCH}" != "$(uname -m)" ]]
+then
+	CROSS_COMPILE="${TARGET_ARCH}-linux-gnu-"
+fi
 
 if [[ $TOOLCHAIN = "llvm" ]]; then
 	export LLVM="-$LLVM_VERSION"
@@ -33,6 +42,8 @@ fi
 cd ${REPO_ROOT}/${REPO_PATH}
 
 MAKE_OPTS=$(cat <<EOF
+	ARCH=${ARCH}
+	CROSS_COMPILE=${CROSS_COMPILE}
 	CLANG=clang-${LLVM_VERSION}
 	LLC=llc-${LLVM_VERSION}
 	LLVM_STRIP=llvm-strip-${LLVM_VERSION}

--- a/helpers.sh
+++ b/helpers.sh
@@ -55,3 +55,40 @@ kernel_build_make_jobs() {
   MAX_MAKE_JOBS=${MAX_MAKE_JOBS:-$smp}
   echo $(( smp > MAX_MAKE_JOBS ? MAX_MAKE_JOBS : smp ))
 }
+
+# Convert a platform (as returned by uname -m) to the kernel
+# arch (as expected by ARCH= env).
+platform_to_kernel_arch() {
+  case $1 in
+    s390x)
+      echo "s390"
+      ;;
+    aarch64)
+      echo "arm64"
+      ;;
+    riscv64)
+      echo "riscv"
+      ;;
+    x86_64)
+      echo "x86"
+      ;;
+    *)
+      echo "$1"
+      ;;
+  esac
+}
+
+# Convert a platform (as returned by uname -m) to its debian equivalent.
+platform_to_deb_arch() {
+  case $1 in
+    aarch64)
+      echo "arm64"
+      ;;
+    x86_64)
+      echo "amd64"
+      ;;
+    *)
+      echo "$1"
+      ;;
+  esac
+}

--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: 'llvm version'
     required: false
     default: '16'
+  arch:
+    description: 'arch'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -38,3 +41,7 @@ runs:
       shell: bash
       run: |
         echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib" >> $GITHUB_ENV
+    - name: Install cross compilation toolchain
+      shell: bash
+      run: |
+         ${GITHUB_ACTION_PATH}/install_cross_compilation_toolchain.sh ${{ inputs.arch }}

--- a/setup-build-env/install_cross_compilation_toolchain.sh
+++ b/setup-build-env/install_cross_compilation_toolchain.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Installs the necessary toolchain to cross compile for ${TARGET_ARCH}
+set -euo pipefail
+
+THISDIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=./helpers.sh
+source "${THISDIR}"/../helpers.sh
+
+TARGET_ARCH="$1"
+
+foldable start install_crosscompile "Installing Cross-Compilation toolchain"
+
+if [[ "${TARGET_ARCH}" != "$(uname -m)" ]]
+then
+	DEB_ARCH="$(platform_to_deb_arch "${TARGET_ARCH}")"
+	# shellcheck source=/dev/null
+	. /etc/os-release
+	cat <<EOF > /etc/apt/sources.list.d/xcompile.list
+deb [arch=${DEB_ARCH}] http://ports.ubuntu.com/ubuntu-ports  ${VERSION_CODENAME} main restricted
+deb [arch=${DEB_ARCH}] http://ports.ubuntu.com/ubuntu-ports  ${VERSION_CODENAME}-updates main restricted
+EOF
+	apt update
+	# Add the architecture
+	dpkg --add-architecture "${DEB_ARCH}"
+	apt install -y g{cc,++}-"${TARGET_ARCH}-linux-gnu" {libelf-dev,libssl-dev}:"${DEB_ARCH}"
+else
+    echo "Nothing to do. Target arch is the same as host arch: ${TARGET_ARCH}"
+fi
+
+foldable end install_crosscompile


### PR DESCRIPTION
This adds handling of a required `arch` parameter.

setup-build-env, build-linux, build-sample, build-selftests are made to handle this input and set the `ARCH` variable when calling `make` to what is expected by Linux build system.

If the `inputs.arch` is different than the host arch, `CROSS_COMPILE` variable will be set to the right toolchain.

`setup-build-env` is also modified to install the corresponding target libraries.