### PR TITLE
ci: Download vmtest binary as root

### DIFF
--- a/run-vmtest/action.yml
+++ b/run-vmtest/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       # FIXME: move to proper release
       run: |
-        curl -L https://github.com/danobi/vmtest/releases/download/v0.12.0/vmtest-$(uname -m) > /usr/bin/vmtest && chmod 755 /usr/bin/vmtest
+        sudo curl -L https://github.com/danobi/vmtest/releases/download/v0.12.0/vmtest-$(uname -m) -o /usr/bin/vmtest && sudo chmod 755 /usr/bin/vmtest
     - name: install qemu tools and selftest dependencies
       shell: bash
       run: |


### PR DESCRIPTION
We were seeing permission issues on the kernel-patches/bpf-rc repo like this:

        Run libbpf/ci/run-vmtest@main
        Run BUILDDIR=$(realpath kbuild-output)
        Run curl -L https://github.com/chantra/danobi-vmtest/releases/download/v2.2.0/vmtest-$(uname -m) > /usr/bin/vmtest && chmod 755 /usr/bin/vmtest
        /home/runner/work/_temp/14c6d06a-568f-4cef-8b61-a2096f0485ed.sh: line 1: /usr/bin/vmtest: Permission denied

This is b/c kernel-patches/bpf runs on self-hosted runners where actions run as root. However, kernel-patches/bpf-ci runs on managed runners where actions are not given root by default.

Fix by ensuring root in both environments.