### PR TITLE
run-vmtest: Configure root-less usage of KVM

### DIFF
--- a/run-vmtest/action.yml
+++ b/run-vmtest/action.yml
@@ -49,6 +49,19 @@ runs:
           ethtool keyutils iptables \
           gawk
         foldable end install_qemu
+    - name: Configure KVM group perms
+      shell: bash
+      run: |
+        source "${GITHUB_ACTION_PATH}/../helpers.sh"
+        foldable start config_kvm "Configuring KVM permissions"
+        # Only configure kvm perms if kvm is available
+        if [[ -e /dev/kvm && ! -w /dev/kvm ]]; then
+          echo "Updating KVM permissions"
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+        fi
+        foldable end config_kvm
     - name: Run vmtest
       shell: bash
       env:


### PR DESCRIPTION
For GH managed runners, KVM is generally available, but we need to configure it so that non-root users can use it. This shouldn't affect the self-hosted runners where we are already root.