### PR TITLE
ci: pass special User-Agent string when downloading kernel sources snapshot

### DIFF
--- a/get-linux-source/checkout_latest_kernel.sh
+++ b/get-linux-source/checkout_latest_kernel.sh
@@ -29,7 +29,9 @@ if [ ! -d "${REPO_PATH}" ]; then
 	mkdir -p $(dirname "${REPO_PATH}")
 	cd $(dirname "${REPO_PATH}")
 	# attempt to fetch desired bpf-next repo snapshot
-	if [ -n "${SNAPSHOT_URL}" ] && wget -nv ${SNAPSHOT_URL} && tar xf bpf-next-${LINUX_SHA}.tar.gz --totals ; then
+	if [ -n "${SNAPSHOT_URL}" ] && \
+	   wget -U 'BPFCIBot/1.0 (bpf@vger.kernel.org)' -nv ${SNAPSHOT_URL} && \
+	   tar xf bpf-next-${LINUX_SHA}.tar.gz --totals ; then
 		mv bpf-next-${LINUX_SHA} $(basename ${REPO_PATH})
 	else
 		# but fallback to git fetch approach if that fails


### PR DESCRIPTION
Konstantin Ryabitsev started blocking requests to download kernel source code snapshots by SHA, generally speaking. For BPF CI, we'll have to use a special User-Agent string to make it work again.