### PR TITLE
ci: Install libpcap for upcoming traffic monitor feature.

### DIFF
--- a/run-vmtest/action.yml
+++ b/run-vmtest/action.yml
@@ -47,7 +47,7 @@ runs:
         # need gawk to support `--field-separator`
         sudo apt-get update && sudo apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent \
           ethtool keyutils iptables \
-          gawk
+          gawk libpcap-dev
         foldable end install_qemu
     - name: Configure KVM group perms
       shell: bash

--- a/run-vmtest/action.yml
+++ b/run-vmtest/action.yml
@@ -24,6 +24,10 @@ inputs:
       Some sub-commands produce output dir within VM file system (/command_output/).
       If this option is set that dir's content would be copied to corresponding location.
     default: ''
+  toolchain:
+    required: true
+    type: string
+    description: The toolchain, e.g gcc, llvm
 runs:
   using: "composite"
   steps:
@@ -74,4 +78,9 @@ runs:
         PROJECT_NAME: "/mnt/vmtest"
       run: |
         ${GITHUB_ACTION_PATH}/run.sh
+    - uses: actions/upload-artifact@v4
+      with:
+        name: tmon-logs-${{ inputs.arch }}-${{ inputs.toolchain }}-${{ inputs.kernel-test }}
+        if-no-files-found: ignore
+        path: tmon-logs
 

--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "::group::Setup"
         sudo apt-get update
-        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
+        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev libpcap0.8-dev python3-docutils
         echo "::endgroup::"
     - name: Install clang
       shell: bash


### PR DESCRIPTION
Traffic monitor is going to be landed on upstream, capturing network traffic in the background for selected test cases. libpcap is required to enable this feature.

Also upload the archives of traffic log files so that developers can download them if necessary.

https://lore.kernel.org/all/20240810023534.2458227-1-thinker.li@gmail.com/

Should be landed after 
https://github.com/kernel-patches/vmtest/pull/280
