### PR TITLE
selftests: override `KHDR_INCLUDES` var

### DIFF
--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -52,6 +52,7 @@ MAKE_OPTS=$(cat <<EOF
 EOF
 )
 SELF_OPTS=$(cat <<EOF
+	KHDR_INCLUDES=-I${KBUILD_OUTPUT}/usr/include
 	-C ${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf
 EOF
 )


### PR DESCRIPTION
In a recent series [1], I suggested to use `KHDR_INCLUDES` variable to avoid having to duplicate UAPI header files.

The BPF CI builds the kernel in a separated directory -- `KBUILD_OUTPUT` variable is set and exported -- and the BPF selftests are executed directly, from the selftests/bpf directory, not from its parent with the `TARGETS` parameter. In this case, it is required to override `KHDR_INCLUDES` to look at the build directory, and not the kernel source, in `usr/include`.

Note that `tools/testing/selftests/Makefile` supports `KBUILD_OUTPUT`, but this Makefile is not used by the BPF CI: it directly uses the one from the bpf directory: `tools/testing/selftests/bpf/Makefile`. That's fine, `KHDR_INCLUDES` can be overridden, that should then fix the build issue seen in [1].

Also, this `KHDR_INCLUDES` variable is not used by the BPF selftests before my series [1]. It is then fine to merge this modification before applying my modifications.

Link: https://lore.kernel.org/bpf/20240816-ups-bpf-next-selftests-use-khdr-v1-0-1e19f3d5b17a@kernel.org/ [1]

-----------

Note that I validated this modification only manually, I didn't try to deploy the CI infrastructure on my side. When applying the same commands as the ones from this script, I can reproduce the issue reported by the CI. Not after having set `KHDR_INCLUDES`.