### PR TITLE
ci: Install llvm repo matching the running distro

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -56,6 +56,12 @@ kernel_build_make_jobs() {
   echo $(( smp > MAX_MAKE_JOBS ? MAX_MAKE_JOBS : smp ))
 }
 
+distro_codename() {
+    DISTRO_CODENAME="noble"
+    test -f /etc/lsb-release && . /etc/lsb-release
+    echo "${DISTRO_CODENAME}"
+}
+
 # Convert a platform (as returned by uname -m) to the kernel
 # arch (as expected by ARCH= env).
 platform_to_kernel_arch() {

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -14,7 +14,9 @@ else
     REPO_DISTRO_SUFFIX="-${LLVM_VERSION}"
 fi
 
-echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal${REPO_DISTRO_SUFFIX} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+DISTRO_CODENAME=$(distro_codename)
+
+echo "deb https://apt.llvm.org/${DISTRO_CODENAME}/ llvm-toolchain-${DISTRO_CODENAME}${REPO_DISTRO_SUFFIX} main" | sudo tee /etc/apt/sources.list.d/llvm.list
 n=0
 while [ $n -lt 5 ]; do
   set +e && \


### PR DESCRIPTION
If no lsb-release file is available, default to `noble`