### PR TITLE
Switch containers to use Ubuntu noble

### DIFF
--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -8,6 +8,7 @@ runner_tmpfs_options:
 runner_gh_token_default: replace with your token
 runner_gh_user_default: replace with your GH user
 runner_docker_tag: main
+runner_docker_ubuntu_version: noble
 runner_docker_image_url: ghcr.io/kernel-patches/runner
 runner_docker_healthcheck: ""
 runner_docker_mount_volume: false

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -55,7 +55,7 @@
   ansible.builtin.copy:
     dest: "{{ runner_base_dir }}/runner_unit.env"
     content: |
-      DOCKER_TAG={{ runner_docker_tag }}-{{ ansible_architecture }}
+      DOCKER_TAG={{ runner_docker_tag }}-{{ runner_docker_ubuntu_version }}-{{ ansible_architecture }}
     mode: 0700
     owner: root
     group: root

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -96,7 +96,7 @@
     content: |
       ACCESS_TOKEN={{ runner_gh_tokens[item.0.name] | default(runner_gh_token_default) }}
       RUNNER_WORKDIR={{ runner_workdir }}
-      LABELS={{ ansible_architecture }},docker-{{ runner_docker_tag }}
+      LABELS={{ ansible_architecture }},docker-{{ runner_docker_ubuntu_version }}-{{ runner_docker_tag }}
       EPHEMERAL=true
       {% if '/' in item.0.name %}
       {# The presence of a / in the name signifies that we have a repo name, otherwise we assume an organization name. #}

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -140,6 +140,8 @@
       TimeoutStartSec=0
       Restart=always
       EnvironmentFile={{ runner_base_dir }}/runner_unit.env
+      # Optionally loaded file. Use this to override per runner environment
+      EnvironmentFile=-{{ runner_base_dir }}/runner_unit-%i.env
       ExecStartPre=-/usr/bin/docker stop %p-%i
       ExecStartPre=-/usr/bin/docker rm %p-%i
       ExecStartPre=-/usr/bin/docker pull {{ runner_docker_image_url }}:${DOCKER_TAG}


### PR DESCRIPTION
This contains a couple of steps:
1. Add the possibility to override on a per runner basis the value of DOCKER_TAG by setting its value in /etc/action-runner/runner_unit-\d\d.env
2. make the containers advertise a new docker-{distro}-main instead of docker-main . Current actions are looking for tag docker-main, so by using this new value, the containers won't be picked up
3. change the value of DOCKER_TAG in /etc/action-runner/runner_unit.env This will make ALL container pick the ubuntu noble container version, and should be deployed only once all actions are running on ubuntu noble.