### PR TITLE
setup-build-env: install llvm development package

### DIFF
--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -55,6 +55,8 @@ SELF_OPTS=$(cat <<EOF
 	-C ${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf
 EOF
 )
+export LLVM_CONFIG=llvm-config-${LLVM_VERSION}
+
 make ${MAKE_OPTS} headers
 make ${MAKE_OPTS} ${SELF_OPTS} clean
 make ${MAKE_OPTS} ${SELF_OPTS} -j $(kernel_build_make_jobs)

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -20,7 +20,7 @@ while [ $n -lt 5 ]; do
   set +e && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
   sudo apt-get update && \
-  sudo apt-get install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION} llvm-${LLVM_VERSION} && \
+  sudo apt-get install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION} llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev && \
   set -e && \
   break
   n=$(($n + 1))


### PR DESCRIPTION
Recently kernel BPF selftests gained an optional dependency on LLVM development libraries [1] in order to support tests that disassemble jit produced code. When necessary dependencies are not available such tests are skipped.

This commit adds LLVM development libraries to the build environment, thus enabling jit disassembly tests on the CI.

[1] https://lore.kernel.org/bpf/20240823080644.263943-1-eddyz87@gmail.com/