### PR TITLE
rootfs: Add riscv64 arch support

### DIFF
--- a/rootfs/Makefile
+++ b/rootfs/Makefile
@@ -1,4 +1,4 @@
-ARCHS = amd64 arm64 s390x
+ARCHS = amd64 arm64 s390x riscv64
 DISTROS = noble
 
 .PHONY: all


### PR DESCRIPTION
@chantra Hi Manu, Hope all is well!

Currently vmtest in bpf selftests already supports riscv64 [0]. Although we also support local rootfs images, for development convenience and subsequent BPF CI support, let us support online riscv64 rootfs image.

Currently I made a commit to add the riscv64 architecture to the rootfs Makefile, but because I don’t have permission, I can’t continue to push the riscv64 rootfs image to the BPF CI Amazon server. Could you help to deal with this?

Link: https://lore.kernel.org/all/20240905081401.1894789-1-pulehui@huaweicloud.com [0]