### PR TITLE
Add build-scx-selftests action

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 100
     env:
-        ARCHIVE_MAKE_HELPERS: ${{ github.repository != 'kernel-patches/bpf' && '1' || '0' }}
+        ARCHIVE_MAKE_HELPERS: ${{ github.repository != 'kernel-patches/bpf' && 'true' || '' }}
         KERNEL: ${{ inputs.kernel }}
         REPO_ROOT: ${{ github.workspace }}
         REPO_PATH: ""
@@ -55,6 +55,7 @@ jobs:
               || github.base_ref
               || 'bpf-next'
           }}
+        BUILD_SCHED_EXT_SELFTESTS: ${{ inputs.arch == 'x86_64' || inputs.arch == 'aarch64' && 'true' || '' }}
     steps:
       - uses: actions/checkout@v4
         # We fetch an actual bit of history here to facilitate incremental
@@ -82,7 +83,8 @@ jobs:
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
       - uses:  ./patch-kernel
         with:
-          repo-root: '${{ github.workspace }}'
+          patches-root: '${{ github.workspace }}/ci/diffs'
+          repo-root: ${{ env.REPO_ROOT }}
       - name: Setup build environment
         uses: ./setup-build-env
         with:
@@ -105,7 +107,7 @@ jobs:
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
           max-make-jobs: 32
           llvm-version: ${{ inputs.llvm-version }}
-      - name: Build selftests
+      - name: Build selftests/bpf
         uses: ./build-selftests
         with:
           arch: ${{ inputs.arch }}
@@ -118,6 +120,16 @@ jobs:
           # RELEASE=0 adds -O0 make flag
           # RELEASE=1 adds -O2 make flag
           RELEASE: ${{ inputs.release && '1' || '' }}
+      - if: ${{ env.BUILD_SCHED_EXT_SELFTESTS }}
+        name: Build selftests/sched_ext
+        uses: ./build-scx-selftests
+        with:
+          kbuild-output: ${{ env.KBUILD_OUTPUT }}
+          repo-root: ${{ env.REPO_ROOT }}
+          arch: ${{ inputs.arch }}
+          toolchain: ${{ inputs.toolchain }}
+          llvm-version: ${{ inputs.llvm-version }}
+          max-make-jobs: 32
       - if: ${{ github.event_name != 'push' }}
         name: Build samples
         uses: ./build-samples
@@ -130,7 +142,7 @@ jobs:
       - name: Tar artifacts
         working-directory: ${{ env.REPO_ROOT }}
         run: |
-          bash .github/scripts/tar-artifact.sh ${{ inputs.arch }} ${{ inputs.toolchain_full }} ${{ env.ARCHIVE_MAKE_HELPERS }}
+          bash .github/scripts/tar-artifact.sh ${{ inputs.arch }} ${{ inputs.toolchain_full }}
       - if: ${{ github.event_name != 'push' }}
         name: Remove KBUILD_OUTPUT content
         shell: bash

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -30,6 +30,7 @@ cat_kernel_config() {
 	cat ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config \
 	    ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.vm \
 	    ${GITHUB_WORKSPACE}/tools/testing/selftests/bpf/config.${TARGET_ARCH} \
+            ${GITHUB_WORKSPACE}/tools/testing/selftests/sched_ext/config \
 	    ${GITHUB_WORKSPACE}/ci/vmtest/configs/config \
 	    ${GITHUB_WORKSPACE}/ci/vmtest/configs/config.${TARGET_ARCH} 2> /dev/null > "${1}"
 }

--- a/build-scx-selftests/README.md
+++ b/build-scx-selftests/README.md
@@ -1,0 +1,20 @@
+# Build selftests/sched_ext
+
+This action builds selftests/sched_ext given a kernel build
+output. Kernel build configuration is supposed to include necessary
+flags (i.e. `tools/testing/selftests/sched_ext/config`).
+
+The action is expected to be executed by a workflow with access to the
+Linux kernel repository.
+
+## Required inputs
+
+* `kbuild-output` - Path to the kernel build output.
+* `repo-root` - Path to the root of the Linux kernel repository.
+* `arch` - Kernel build architecture.
+* `toolchain` - Toolchain name: `gcc` (default) or `llvm`.
+
+## Optional inputs
+* `llvm-version` - LLVM version, used when `toolchain` is `llvm`. Default: `16`.
+* `max-make-jobs` - Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc.
+

--- a/build-scx-selftests/action.yml
+++ b/build-scx-selftests/action.yml
@@ -1,0 +1,34 @@
+name: 'Build selftests/sched_ext'
+inputs:
+  kbuild-output:
+    description: 'Path to the kernel build output'
+    required: true
+  repo-root:
+    description: "Path to the root of the kernel repository"
+    required: true
+  arch:
+    description: 'arch'
+    required: true
+  toolchain:
+    description: 'gcc or llvm'
+    default: 'gcc'
+    required: true
+  llvm-version:
+    description: 'llvm version'
+    required: false
+    default: '16'
+  max-make-jobs:
+    description: 'Maximum number of jobs to use when running make (e.g argument to -j). Default: 4*nproc'
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build selftests/sched_ext
+      env:
+        KBUILD_OUTPUT: ${{ inputs.kbuild-output }}
+        MAX_MAKE_JOBS: ${{ inputs.max-make-jobs }}
+        REPO_ROOT: ${{ inputs.repo-root || github.workspace }}
+      shell: bash
+      run:
+        ${GITHUB_ACTION_PATH}/build.sh "${{ inputs.arch }}" "${{ inputs.toolchain }}" "${{ inputs.llvm-version }}"

--- a/build-scx-selftests/build.sh
+++ b/build-scx-selftests/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "${GITHUB_ACTION_PATH}/../helpers.sh"
+
+TARGET_ARCH=$1
+TOOLCHAIN=$2
+LLVM_VERSION=$3
+
+ARCH="$(platform_to_kernel_arch ${TARGET_ARCH})"
+CROSS_COMPILE=""
+
+if [[ "${TARGET_ARCH}" != "$(uname -m)" ]]
+then
+	CROSS_COMPILE="${TARGET_ARCH}-linux-gnu-"
+fi
+
+if [[ $TOOLCHAIN = "llvm" ]]; then
+	export LLVM="-$LLVM_VERSION"
+	TOOLCHAIN="llvm-$LLVM_VERSION"
+fi
+
+foldable start build_selftests "Building selftests/sched_ext with $TOOLCHAIN"
+
+MAKE_OPTS=$(cat <<EOF
+	ARCH=${ARCH}
+	CROSS_COMPILE=${CROSS_COMPILE}
+	CLANG=clang-${LLVM_VERSION}
+	LLC=llc-${LLVM_VERSION}
+	LLVM_STRIP=llvm-strip-${LLVM_VERSION}
+	VMLINUX_BTF=${KBUILD_OUTPUT}/vmlinux
+EOF
+)
+SELF_OPTS=$(cat <<EOF
+	-C ${REPO_ROOT}/tools/testing/selftests/sched_ext
+EOF
+)
+
+cd ${REPO_ROOT}
+make ${MAKE_OPTS} ${SELF_OPTS} clean
+make ${MAKE_OPTS} ${SELF_OPTS} -j $(kernel_build_make_jobs)
+
+foldable end build_selftests
+

--- a/build-selftests/build_selftests.sh
+++ b/build-selftests/build_selftests.sh
@@ -26,8 +26,6 @@ fi
 
 foldable start build_selftests "Building selftests with $TOOLCHAIN"
 
-LIBBPF_PATH="${REPO_ROOT}"
-
 PREPARE_SELFTESTS_SCRIPT=${THISDIR}/prepare_selftests-${KERNEL}.sh
 if [ -f "${PREPARE_SELFTESTS_SCRIPT}" ]; then
 	(cd "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" && ${PREPARE_SELFTESTS_SCRIPT})
@@ -58,11 +56,5 @@ EOF
 make ${MAKE_OPTS} headers
 make ${MAKE_OPTS} ${SELF_OPTS} clean
 make ${MAKE_OPTS} ${SELF_OPTS} -j $(kernel_build_make_jobs)
-
-cd -
-mkdir "${LIBBPF_PATH}"/selftests
-cp -R "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
-  "${LIBBPF_PATH}"/selftests
-cd "${LIBBPF_PATH}"
 
 foldable end build_selftests


### PR DESCRIPTION
Add `build-scx-selftests` action. This action will build `tools/testsing/selftests/sched_ext` binaries, given kbuild-output and toolchain parameters passed to the action.

The action and its build script are very similar to `build-selftests`. Build scipt is simplified somewhat.

Action inputs are different:
* `repo-root` is a new required parameter, because we don't want to rely on the assuption that `$REPO_ROOT` == `github.workspace`
* `kernel` is removed: it controled the location of `vmlinux.h`, but it is generated from the `$KBUILD_OUTPUT/vmlinux`, and I don't think we need to be able to customize it (at least not yet)
    * https://github.com/kernel-patches/bpf/blob/bpf-next_base/tools/testing/selftests/sched_ext/Makefile#L125-L131
    * https://github.com/theihor/libbpf-ci/blob/build-scx/build-scx-selftests/build.sh#L30