### PR TITLE
[ansible][qemu-user-static] Force automount to mount /proc/sys/fs/bin…

### DIFF
--- a/ansible/roles/qemu-user-static/tasks/main.yml
+++ b/ansible/roles/qemu-user-static/tasks/main.yml
@@ -13,6 +13,8 @@
       # https://github.com/multiarch/qemu-user-static does not support host arch != x86_64
       # see https://github.com/multiarch/qemu-user-static/issues/174
       # In the meantime use https://dbhi.github.io/qus/
+      # The command below is a stupid trick to ensure that systemd units for binfmt (proc-sys-fs-binfmt_misc.{auto,}mount are kicked and properly mount the FS before we run qemu-user-static
+      ExecStartPre=-/bin/ls /proc/sys/fs/binfmt_misc
       ExecStartPre=/usr/bin/docker run --rm --interactive --privileged {{ qus_container_name }}:{{ qus_container_tag }} -s -- -r
       ExecStart=/usr/bin/docker run --rm --interactive --privileged {{ qus_container_name }}:{{ qus_container_tag }} -s -- -p
 


### PR DESCRIPTION
…fmt_misc

systemd is kind of taking over that directory. While Ubuntu seems to handle this just right, Amazon Linux 2 does not, essentially, the directory is handled by automount, but is not mounted and onl;y ends up mounted once we try to access it with `ls` or such. This gets us to end up in a situation where qemu-user-static has ran, but its config gets overridden.

I did not manage to get this to work properly on AL2, but we can trick it by "pre-warming" the mount by running a `ls /proc/sys/fs/binfmt_misc` as a pre-exec-start step (ignoring failures).

Tried this on Ubuntu host, and there were still happy.
Signed-off-by: Manu Bretelle <chantr4@gmail.com>