### PR TITLE
setup-build-env: Install libzstd-dev

### DIFF
--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "::group::Setup"
         sudo apt-get update
-        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
+        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd libzstd-dev binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
         echo "::endgroup::"
     - name: Install clang
       shell: bash


### PR DESCRIPTION
sched-ext selftests link against zstd. It currently fails with the following linker error:

    rc/tools/testing/selftests/sched_ext/build/obj/sched_ext/test_example.o -lelf -lz -lpthread -lzstd
    /usr/bin/ld: cannot find -lzstd
    collect2: error: ld returned 1 exit status

Fix by installing zstd-dev package.