### PR TITLE
rc: Denylist send_signal/send_signal_nmi_remote

### DIFF
--- a/ci/vmtest/configs/DENYLIST.rc
+++ b/ci/vmtest/configs/DENYLIST.rc
@@ -1,3 +1,4 @@
 send_signal/send_signal_nmi            # PMU events configure correctly but don't trigger NMI's for some reason (AMD nested virt)
+send_signal/send_signal_nmi_remote     # Same as above
 send_signal/send_signal_nmi_thread     # Same as above
 token/obj_priv_implicit_token_envvar   # Unknown root cause, but reliably fails


### PR DESCRIPTION
The test hangs in GH hosted runners:

    WATCHDOG: test case send_signal/send_signal_nmi_remote executes for 10 seconds...
    WATCHDOG: test case send_signal/send_signal_nmi_remote executes for 300 seconds, terminating with SIGSEGV
    Caught signal #11!
    Stack trace:
    ./test_progs(crash_handler+0x38)[0x5556294291b2]
    /lib/x86_64-linux-gnu/libpthread.so.0(+0x14420)[0x7f39721c0420]
    ./test_progs(+0x33fa71)[0x5556293a7a71]
    ./test_progs(+0x340231)[0x5556293a8231]
    ./test_progs(test_send_signal+0x11f)[0x5556293a8366]
    ./test_progs(+0x3c173f)[0x55562942973f]
    ./test_progs(main+0x5af)[0x55562942b418]
    /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3)[0x7f3971fde083]
    ./test_progs(_start+0x2e)[0x55562909f26e]

The root cause is the same as the other send_signal_nmi tests, so just deny for RC.