### PR TITLE
prepare-incremental-build: don't fail

### DIFF
--- a/prepare-incremental-build/action.yml
+++ b/prepare-incremental-build/action.yml
@@ -49,5 +49,5 @@ runs:
       env:
         KBUILD_OUTPUT: ${{ inputs.kbuild-output }}
       shell: bash
-      run: ${GITHUB_ACTION_PATH}/prepare-incremental-builds.sh ${{ steps.get-commit-metadata.outputs.commit }}
+      run: ${GITHUB_ACTION_PATH}/prepare-incremental-builds.sh ${{ steps.get-commit-metadata.outputs.commit }} || echo "Prepare incremental build script failed! Continue anyway..."
 


### PR DESCRIPTION
Print a message and return 0 exit code, even if a script failed.

prepare-incremental-build action is meant to speed up the build, and should not fail a job in case of failure.