### PR TITLE
Enable traffic monitoring to debug flaky selftests

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -82,3 +82,9 @@ jobs:
           # Here we must use kbuild-output local to the repo, because
           # it was extracted from the artifacts.
           kbuild-output: ${{ env.REPO_ROOT }}/kbuild-output
+      - if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tmon-logs-${{ inputs.arch }}-${{ inputs.toolchain_full }}-${{ inputs.test }}
+          if-no-files-found: ignore
+          path: /tmp/tmon_pcap/*

--- a/run-vmtest/action.yml
+++ b/run-vmtest/action.yml
@@ -48,7 +48,7 @@ runs:
         foldable start install_qemu "Installing QEMU tools"
         # need gawk to support `--field-separator`
         sudo apt-get update && sudo apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent \
-          ethtool keyutils iptables \
+          ethtool keyutils iptables libpcap-dev \
           gawk
         foldable end install_qemu
     - name: Configure KVM group perms

--- a/run-vmtest/run-bpf-selftests.sh
+++ b/run-vmtest/run-bpf-selftests.sh
@@ -42,6 +42,7 @@ test_progs_helper() {
   args+=(${ALLOWLIST_FILE:+-a@$ALLOWLIST_FILE})
   args+=(${DENYLIST_FILE:+-d@$DENYLIST_FILE})
   args+=(-J "${json_file}")
+  args+=(-m '*')
 
   foldable start ${selftest} "Testing ${selftest}"
   echo "./${selftest}" "${args[@]}"

--- a/run-vmtest/run-bpf-selftests.sh
+++ b/run-vmtest/run-bpf-selftests.sh
@@ -25,11 +25,11 @@ OUTPUT_DIR=${OUTPUT_DIR:-/mnt/vmtest}
 
 test_progs_helper() {
   local selftest="test_progs${1}"
-  local args="$2"
+  local args=("$2")
 
-  args+=" ${TEST_PROGS_WATCHDOG_TIMEOUT:+-w$TEST_PROGS_WATCHDOG_TIMEOUT}"
-  args+=" ${ALLOWLIST_FILE:+-a@$ALLOWLIST_FILE}"
-  args+=" ${DENYLIST_FILE:+-d@$DENYLIST_FILE}"
+  if [ "${args[0]}" == "" ]; then
+	args=("${args[@]:1}")
+  fi
 
   json_file=${selftest/-/_}
   if [ "$2" == "-j" ]
@@ -38,12 +38,17 @@ test_progs_helper() {
   fi
   json_file="${OUTPUT_DIR}/${json_file}.json"
 
+  args+=(${TEST_PROGS_WATCHDOG_TIMEOUT:+-w$TEST_PROGS_WATCHDOG_TIMEOUT})
+  args+=(${ALLOWLIST_FILE:+-a@$ALLOWLIST_FILE})
+  args+=(${DENYLIST_FILE:+-d@$DENYLIST_FILE})
+  args+=(-J "${json_file}")
+
   foldable start ${selftest} "Testing ${selftest}"
-  echo "./${selftest} ${args} --json-summary \"${json_file}\""
+  echo "./${selftest}" "${args[@]}"
   # "&& true" does not change the return code (it is not executed
   # if the Python script fails), but it prevents exiting on a
   # failure due to the "set -e".
-  ./${selftest} ${args} --json-summary "${json_file}" && true
+  ./${selftest} "${args[@]}" && true
   echo "${selftest}:$?" >>"${STATUS_FILE}"
   foldable end ${selftest}
 }

--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "::group::Setup"
         sudo apt-get update
-        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils zstd libzstd-dev binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils texinfo
+        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils zstd libzstd-dev binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils texinfo libpcap-dev
         echo "::endgroup::"
     - name: Install clang
       shell: bash


### PR DESCRIPTION
Traffic monitoring was add to the selftests/bpf[0] to debug some flaky test cases. Enable this in CI by building selftests with libpcap, installing libpcap in the test environment and finally turn it on when running the test.

[0] https://lore.kernel.org/bpf/20240815053254.470944-1-thinker.li@gmail.com/