### PR TITLE
GCC BPF: factor out into a separate job

### DIFF
--- a/.github/workflows/gcc-bpf.yml
+++ b/.github/workflows/gcc-bpf.yml
@@ -1,0 +1,84 @@
+name: Testing GCC BPF compiler
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      llvm-version:
+        required: true
+        type: string
+      toolchain:
+        required: true
+        type: string
+      toolchain_full:
+        required: true
+        type: string
+      download_sources:
+        required: true
+        type: boolean
+
+jobs:
+  test:
+    name: GCC BPF
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: 100
+    env:
+      ARCH: ${{ inputs.arch }}
+      BPF_GCC_INSTALL_DIR: ${{ github.workspace }}/gcc-bpf
+      BPF_NEXT_BASE_BRANCH: 'master'
+      REPO_ROOT: ${{ github.workspace }}/src
+      KBUILD_OUTPUT: ${{ github.workspace }}/src/kbuild-output
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - if: ${{ inputs.download_sources }}
+        name: Download bpf-next tree
+        uses: libbpf/ci/get-linux-source@v3
+        with:
+          dest: ${{ env.REPO_ROOT }}
+          rev: ${{ env.BPF_NEXT_BASE_BRANCH }}
+
+      - uses: ./patch-kernel
+        with:
+          patches-root: '${{ github.workspace }}/ci/diffs'
+          repo-root: ${{ env.REPO_ROOT }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: vmlinux-${{ inputs.arch }}-${{ inputs.toolchain_full }}
+          path: ${{ env.REPO_ROOT }}
+
+      - name: Untar artifacts
+        working-directory: ${{ env.REPO_ROOT }}
+        run: zstd -d -T0 vmlinux-${{ inputs.arch }}-${{ inputs.toolchain_full }}.tar.zst --stdout | tar -xf -
+
+      - name: Setup build environment
+        uses: ./setup-build-env
+        with:
+          arch: ${{ inputs.arch }}
+          llvm-version: ${{ inputs.llvm-version }}
+
+      - name: Build GCC BPF compiler
+        uses: ./build-bpf-gcc
+        with:
+          install-dir: ${{ env.BPF_GCC_INSTALL_DIR }}
+
+      - name: Build selftests/bpf/test_progs-bpf_gcc
+        uses: ./build-selftests
+        env:
+          MAX_MAKE_JOBS: 32
+          BPF_GCC: ${{ env.BPF_GCC_INSTALL_DIR }}
+          SELFTESTS_BPF_TARGETS: 'test_progs-bpf_gcc'
+        with:
+          arch: ${{ inputs.arch }}
+          kernel-root: ${{ env.REPO_ROOT }}
+          llvm-version: ${{ inputs.llvm-version }}
+          toolchain: ${{ inputs.toolchain }}
+

--- a/.github/workflows/kernel-build-test.yml
+++ b/.github/workflows/kernel-build-test.yml
@@ -62,6 +62,7 @@ jobs:
       llvm-version: ${{ inputs.llvm-version }}
       kernel: ${{ inputs.kernel }}
       download_sources: ${{ inputs.download_sources }}
+
   build-release:
     if: ${{ inputs.build_release }}
     uses: ./.github/workflows/kernel-build.yml
@@ -74,6 +75,7 @@ jobs:
       kernel: ${{ inputs.kernel }}
       download_sources: ${{ inputs.download_sources }}
       release: true
+
   test:
     if: ${{ inputs.run_tests }}
     uses: ./.github/workflows/kernel-test.yml
@@ -92,3 +94,17 @@ jobs:
       test: ${{ matrix.test }}
       continue_on_error: ${{ toJSON(matrix.continue_on_error) }}
       timeout_minutes: ${{ matrix.timeout_minutes }}
+
+  gcc-bpf:
+    name: 'GCC BPF'
+    if: ${{ inputs.arch == 'x86_64' }}
+    uses: ./.github/workflows/gcc-bpf.yml
+    needs: [build]
+    with:
+      runs_on: ${{ inputs.runs_on }}
+      arch: ${{ inputs.arch }}
+      llvm-version: ${{ inputs.llvm-version }}
+      toolchain: ${{ inputs.toolchain }}
+      toolchain_full: ${{ inputs.toolchain_full }}
+      download_sources: ${{ inputs.download_sources }}
+

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -46,10 +46,6 @@ jobs:
     timeout-minutes: 100
     env:
         ARTIFACTS_ARCHIVE: "vmlinux-${{ inputs.arch }}-${{ inputs.toolchain_full }}.tar.zst"
-
-        BUILD_BPF_GCC: ${{ inputs.arch == 'x86_64' && 'true' || '' }}
-        BPF_GCC_INSTALL_DIR: ${{ github.workspace }}/bpf-gcc
-
         BPF_NEXT_BASE_BRANCH: 'master'
         BPF_NEXT_FETCH_DEPTH: 64 # A bit of history is needed to facilitate incremental builds
         # BUILD_SCHED_EXT_SELFTESTS: ${{ inputs.arch == 'x86_64' || inputs.arch == 'aarch64' && 'true' || '' }}
@@ -112,18 +108,11 @@ jobs:
           max-make-jobs: 32
           llvm-version: ${{ inputs.llvm-version }}
 
-      - if: ${{ env.BUILD_BPF_GCC }}
-        name: Build GCC for BPF selftests
-        uses: ./build-bpf-gcc
-        with:
-          install-dir: ${{ env.BPF_GCC_INSTALL_DIR }}
-
       - name: Build selftests/bpf
         uses: ./build-selftests
         env:
           MAX_MAKE_JOBS: 32
           RELEASE: ${{ inputs.release && '1' || '' }}
-          BPF_GCC: ${{ env.BUILD_BPF_GCC && env.BPF_GCC_INSTALL_DIR || '' }}
         with:
           arch: ${{ inputs.arch }}
           kernel-root: ${{ env.KERNEL_ROOT }}


### PR DESCRIPTION
In order to test selftests/bpf build with GCC BPF, the latest snapshot of GCC BPF compiler has to built from source.

We don't want this to be a dependency for all the test runners, so
introduce a separate gcc-bpf workflow that executes the following:
  * checkout Linux source tree and patch it (as in kernel-build)
  * download relevant artifacts with the KBUILD_OUTPUT objects (as in
    kernel-test)
  * build/download GCC BPF compiler
  * build selftests/bpf/test_progs-bpf_gcc runner, hence the test BPF
    objects built with GCC

The test_progs-bpf_gcc runner is not executed on BPF CI yet [1], so successful selftests build is a successful job run.

[1] https://lore.kernel.org/bpf/87bjw6qpje.fsf@oracle.com/