### PR TITLE
setup-build-env: Install pkg-config for bpf selftests traffic monitoring

### DIFF
--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "::group::Setup"
         sudo apt-get update
-        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils zstd libzstd-dev binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils texinfo libpcap-dev
+        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils zstd libzstd-dev binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils texinfo libpcap-dev pkg-config
         echo "::endgroup::"
     - name: Install clang
       shell: bash


### PR DESCRIPTION
Install pkg-config in setup-build-env explicitly so that we can build bpf selftests with traffic monitor without depending on the runner. Currently, s390 runner image does not include pkg-config required by bpf selftests traffic monitor. During compile time, the makefile uses pkg-config to check if libpcap is installed and determines if traffic monitoring feature will be compiled into test_progs.