### PR TITLE
run-vmtest: conditionally pass -m to test_progs

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -72,6 +72,7 @@ jobs:
           KERNEL_TEST: ${{ inputs.test }}
           SELFTESTS_BPF: ${{ github.workspace }}/selftests/bpf
           VMTEST_CONFIGS: ${{ github.workspace }}/ci/vmtest/configs
+          TEST_PROGS_TRAFFIC_MONITOR: ${{ inputs.arch == 'x86_64' && 'true' || '' }}
           TEST_PROGS_WATCHDOG_TIMEOUT: 300
         with:
           arch: ${{ inputs.arch }}

--- a/run-vmtest/run-bpf-selftests.sh
+++ b/run-vmtest/run-bpf-selftests.sh
@@ -42,7 +42,7 @@ test_progs_helper() {
   args+=(${ALLOWLIST_FILE:+-a@$ALLOWLIST_FILE})
   args+=(${DENYLIST_FILE:+-d@$DENYLIST_FILE})
   args+=(-J "${json_file}")
-  args+=(-m '*')
+  args+=(${TEST_PROGS_TRAFFIC_MONITOR:+-m '*'})
 
   foldable start ${selftest} "Testing ${selftest}"
   echo "./${selftest}" "${args[@]}"


### PR DESCRIPTION
Use TEST_PROGS_TRAFFIC_MONITOR env variable to control whether to enable traffic monitor in test_progs. It depends on selftests being built with libpcap-dev.