### PR TITLE
get-linux-source: always do git fetch

### DIFF
--- a/.github/workflows/gcc-bpf.yml
+++ b/.github/workflows/gcc-bpf.yml
@@ -45,7 +45,7 @@ jobs:
 
       - if: ${{ inputs.download_sources }}
         name: Download bpf-next tree
-        uses: libbpf/ci/get-linux-source@v3
+        uses: ./get-linux-source
         with:
           dest: ${{ env.REPO_ROOT }}
           rev: ${{ env.BPF_NEXT_BASE_BRANCH }}

--- a/get-linux-source/checkout_latest_kernel.sh
+++ b/get-linux-source/checkout_latest_kernel.sh
@@ -1,69 +1,22 @@
 #!/bin/bash
 
-set -euo pipefail
+set -xeuo pipefail
 
-source $(cd $(dirname $0) && pwd)/../helpers.sh
-
-CWD=$(pwd)
-
-# 0 means just download a snapshot
-FETCH_DEPTH=${FETCH_DEPTH:-0}
+FETCH_DEPTH=${FETCH_DEPTH:-1}
 
 echo KERNEL_ORIGIN = ${KERNEL_ORIGIN}
 echo KERNEL_BRANCH = ${KERNEL_BRANCH}
 echo REPO_PATH = ${REPO_PATH}
 
-SNAPSHOT_URL=''
-if [[ "${KERNEL_BRANCH}" = 'master' ]]; then
-  echo "using ${KERNEL_BRANCH} sha1"
-  LINUX_SHA=$(git ls-remote ${KERNEL_ORIGIN} ${KERNEL_BRANCH} | awk '{print $1}')
-else
-  LINUX_SHA=${KERNEL_BRANCH}
-fi
-SNAPSHOT_URL=${KERNEL_ORIGIN}/snapshot/bpf-next-${LINUX_SHA}.tar.gz
-
-echo LINUX_SHA = ${LINUX_SHA}
-echo SNAPSHOT_URL = ${SNAPSHOT_URL}
-
 if [ -d "${REPO_PATH}" ]; then
     echo "${REPO_PATH} directory already exists, will not download kernel sources"
-    exit 0
+    exit 1
 fi
 
-mkdir -p $(dirname "${REPO_PATH}")
-cd $(dirname "${REPO_PATH}")
+mkdir -p "${REPO_PATH}"
+cd "${REPO_PATH}"
 
-# attempt to fetch desired bpf-next repo snapshot
-if [[ -n "${SNAPSHOT_URL}" && "${FETCH_DEPTH}" -le 0 ]]; then
-    wget -U 'BPFCIBot/1.0 (bpf@vger.kernel.org)' -nv ${SNAPSHOT_URL} || true
-    PRESERVE_DOT_GIT=
-else
-    PRESERVE_DOT_GIT=true
-fi
-
-tarball=bpf-next-${LINUX_SHA}.tar.gz
-if [[ -f "$tarball" ]]; then
-    tar xf "$tarball" --totals
-    mv bpf-next-${LINUX_SHA} $(basename ${REPO_PATH})
-else
-    # FETCH_DEPTH can be 0 here in case snapshot download has failed
-    if [ "${FETCH_DEPTH}" -le 0 ]; then
-        FETCH_DEPTH=1
-    fi
-
-    git clone --depth ${FETCH_DEPTH} ${KERNEL_ORIGIN} ${REPO_PATH}
-
-    cd "${REPO_PATH}"
-    # check if desired SHA exists
-    if ! git cat-file -e ${LINUX_SHA}^{commit} ; then
-        # if not, fetch all of bpf-next; slow and painful
-	git fetch origin
-    fi
-    git reset --hard ${LINUX_SHA}
-    cd -
-fi
-
-if [ -z "${PRESERVE_DOT_GIT}" ]; then
-    rm -rf ${REPO_PATH}/.git || true
-fi
-
+git init
+git remote add origin ${KERNEL_ORIGIN}
+git fetch --depth=${FETCH_DEPTH} origin ${KERNEL_BRANCH}
+git checkout FETCH_HEAD


### PR DESCRIPTION
Recently proof-of-work proxy was rolled out for git.kernel.org, which prevents wget of the bpf-next snapshots.

This lead to failures of get-linux-source action:
* https://github.com/kernel-patches/vmtest/actions/runs/14313967784/job/40115985369
* https://github.com/libbpf/libbpf/actions/runs/14316467048/job/40123652831

Simplify the download script to always run git init + git fetch sequence.

[1] https://social.kernel.org/notice/AsgziNL6zgmdbta3lY