### PR TITLE
setup-build-env: do not downgrade linux-libc-dev

### DIFF
--- a/setup-build-env/install_cross_compilation_toolchain.sh
+++ b/setup-build-env/install_cross_compilation_toolchain.sh
@@ -49,9 +49,6 @@ EOF
 
 sudo apt-get update -y
 
-# downgrade due to conflict with linux-libc-dev:s390x
-sudo apt-get install --allow-downgrades -y linux-libc-dev=6.8.0-57.59
-
 sudo apt-get install -y                  \
      "crossbuild-essential-${DEB_ARCH}"  \
      "binutils-${TARGET_ARCH}-linux-gnu" \


### PR DESCRIPTION
The downgrade helped mitigate package conflicts between linux-libc-dev:amd64 and s390x packages.

Revert the downgrade command.