### PR TITLE
setup-build-env: configurable GCC version

### DIFF
--- a/setup-build-env/action.yml
+++ b/setup-build-env/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: 'llvm version'
     required: false
     default: '16'
+  gcc-version:
+    required: false
+    default: '13'
   arch:
     description: 'arch'
     required: true
@@ -21,27 +24,27 @@ runs:
   steps:
     - name: Setup environment
       shell: bash
+      env:
+        GCC_VERSION: ${{ inputs.gcc-version }}
       run: |
-        echo "::group::Setup"
-        sudo apt-get update
-        sudo apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils zstd libzstd-dev binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils texinfo libpcap-dev pkg-config
-        echo "::endgroup::"
+        ${GITHUB_ACTION_PATH}/install_packages.sh
     - name: Install clang
       shell: bash
+      env:
+        LLVM_VERSION: ${{ inputs.llvm-version }}
       run: |
-        export LLVM_VERSION=${{ inputs.llvm-version }}
         ${GITHUB_ACTION_PATH}/install_clang.sh
     - name: Install pahole
       shell: bash
+      env:
+        PAHOLE_BRANCH: ${{ inputs.pahole }}
+        PAHOLE_ORIGIN: ${{ inputs.pahole-origin }}
       run: |
-        export PAHOLE_BRANCH=${{ inputs.pahole }}
-        export PAHOLE_ORIGIN=${{ inputs.pahole-origin }}
         ${GITHUB_ACTION_PATH}/build_pahole.sh
-    - name: set pahole location
-      shell: bash
-      run: |
         echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib" >> $GITHUB_ENV
     - name: Install cross compilation toolchain
       shell: bash
+      env:
+        GCC_VERSION: ${{ inputs.gcc-version }}
       run: |
          ${GITHUB_ACTION_PATH}/install_cross_compilation_toolchain.sh ${{ inputs.arch }}

--- a/setup-build-env/build_pahole.sh
+++ b/setup-build-env/build_pahole.sh
@@ -14,7 +14,8 @@ source $(cd $(dirname $0) && pwd)/../helpers.sh
 
 foldable start build_pahole "Building pahole"
 
-sudo apt-get update && sudo apt-get install elfutils libelf-dev libdw-dev
+sudo apt-get update -y
+sudo apt-get install -y --no-install-recommends elfutils libelf-dev libdw-dev
 
 CWD=$(pwd)
 

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -1,34 +1,13 @@
 #!/bin/bash
 set -eu
 
-source $(cd $(dirname $0) && pwd)/../helpers.sh
+THISDIR="$(cd "$(dirname "$0")" && pwd)"
+source "${THISDIR}"/../helpers.sh
 
-# Install required packages
-foldable start install_clang "Installing Clang/LLVM"
-sudo apt-get update
-sudo apt-get install -y g++ libelf-dev
+foldable start install_clang "Install LLVM ${LLVM_VERSION}"
 
-if [[ "${LLVM_VERSION}" == $(llvm_latest_version) ]] ; then
-    REPO_DISTRO_SUFFIX=""
-else
-    REPO_DISTRO_SUFFIX="-${LLVM_VERSION}"
-fi
+curl -O https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh ${LLVM_VERSION}
 
-DISTRIB_CODENAME=$(distrib_codename)
-
-echo "deb https://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME}${REPO_DISTRO_SUFFIX} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-n=0
-while [ $n -lt 5 ]; do
-  set +e && \
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-  sudo apt-get update && \
-  sudo apt-get install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION} llvm-${LLVM_VERSION} && \
-  set -e && \
-  break
-  n=$(($n + 1))
-done
-if [ $n -ge 5 ] ; then
-  echo "clang install failed"
-  exit 1
-fi
 foldable end install_clang

--- a/setup-build-env/install_cross_compilation_toolchain.sh
+++ b/setup-build-env/install_cross_compilation_toolchain.sh
@@ -20,6 +20,7 @@ source /etc/os-release
 DEB_ARCH="$(platform_to_deb_arch "${TARGET_ARCH}")"
 DEB_HOST_ARCH="$(dpkg --print-architecture)"
 UBUNTU_CODENAME=${VERSION_CODENAME:-noble}
+GCC_VERSION=${GCC_VERSION:-14}
 
 cat <<EOF | sudo tee /etc/apt/sources.list.d/ubuntu.sources
 Types:        deb
@@ -48,15 +49,22 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
 
 sudo apt-get update -y
-
-sudo apt-get install -y                  \
-     "crossbuild-essential-${DEB_ARCH}"  \
-     "binutils-${TARGET_ARCH}-linux-gnu" \
-     "gcc-${TARGET_ARCH}-linux-gnu"      \
-     "g++-${TARGET_ARCH}-linux-gnu"      \
-     "linux-libc-dev:${DEB_ARCH}"        \
-     "libelf-dev:${DEB_ARCH}"            \
-     "libssl-dev:${DEB_ARCH}"            \
+sudo apt-get install -y --no-install-recommends    \
+     "gcc-${GCC_VERSION}-${TARGET_ARCH}-linux-gnu" \
+     "g++-${GCC_VERSION}-${TARGET_ARCH}-linux-gnu" \
+     "linux-libc-dev:${DEB_ARCH}"                  \
+     "libelf-dev:${DEB_ARCH}"                      \
+     "libssl-dev:${DEB_ARCH}"                      \
      "zlib1g-dev:${DEB_ARCH}"
+
+sudo update-alternatives --install \
+     /usr/bin/${TARGET_ARCH}-linux-gnu-gcc  \
+     ${TARGET_ARCH}-linux-gnu-gcc           \
+     /usr/bin/${TARGET_ARCH}-linux-gnu-gcc-${GCC_VERSION} 10
+
+sudo update-alternatives --install \
+     /usr/bin/${TARGET_ARCH}-linux-gnu-g++  \
+     ${TARGET_ARCH}-linux-gnu-g++           \
+     /usr/bin/${TARGET_ARCH}-linux-gnu-g++-${GCC_VERSION} 10
 
 foldable end install_crosscompile

--- a/setup-build-env/install_packages.sh
+++ b/setup-build-env/install_packages.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+THISDIR="$(cd "$(dirname "$0")" && pwd)"
+source "${THISDIR}"/../helpers.sh
+
+export DEBIAN_FRONTEND=noninteractive
+export GCC_VERSION=${GCC_VERSION:-14}
+
+foldable start install_packages
+
+sudo apt-get update -y
+
+sudo -E apt-get install --no-install-recommends -y                    \
+     bc binutils-dev bison build-essential cmake curl elfutils flex   \
+     libcap-dev libdw-dev libelf-dev libguestfs-tools libpcap-dev     \
+     libssl-dev libzstd-dev ncurses-dev pkg-config python3-docutils   \
+     qemu-kvm qemu-utils rsync texinfo tzdata xz-utils zstd
+
+sudo apt-get install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 10
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 10
+
+foldable end install_packages


### PR DESCRIPTION
Refactor setup-build-env to accept optional gcc-version action input
to control what version of GCC is installed.

Refactor "setup environment" step into a separate install_packages.sh
script.

Simplify install_clang.sh by utilizing officially distributed
installation script [1].

Use update-alternatives to make sure the specified version of GCC is
the system default, when installed via setup-build-env action.

[1] https://apt.llvm.org/