### PR TITLE
Add randomized suffix to runner names

### DIFF
--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -105,7 +105,8 @@
       RUNNER_SCOPE=org
       ORG_NAME={{ item.0.name }}
       {% endif %}
-      RUNNER_NAME={{ runner_name_prefix }}-{{ 'worker-%02d' | format(item.1) }}
+      RUNNER_NAME_PREFIX={{ runner_name_prefix }}-{{ 'worker-%02d' | format(item.1) }}
+      RANDOM_RUNNER_SUFFIX=true
       DISABLE_AUTO_UPDATE=true
   loop: "{{ runners | subelements('workers') }}"
 
@@ -139,6 +140,7 @@
       [Service]
       TimeoutStartSec=0
       Restart=always
+      RestartPreventExitStatus=199
       EnvironmentFile={{ runner_base_dir }}/runner_unit.env
       # Optionally loaded file. Use this to override per runner environment
       EnvironmentFile=-{{ runner_base_dir }}/runner_unit-%i.env


### PR DESCRIPTION
BPF CI runners went down recently due to a problem caused by "Runner not found" error returned from a github broker service [1].

It appears that this error may be triggered by the fact that runner names are reused for "different" runners from the perspective of github. In BPF CI we use ephemeral runners which re-register every time a corresponding runner container is restarted.

Whatever the root cause, a working mitigation is to use unique runner names. Fortunately, entrypoint.sh [1] already has the logic of generating a random suffix, and we only need to set relevant environment variables.

Additionally, set RestartPreventExitStatus=199 in the runner systemd service to prevent error looping in case we run out of tokens [2].

[1] https://github.com/myoung34/docker-github-actions-runner/blob/2.323.0/entrypoint.sh
[2] https://github.com/kernel-patches/runner/pull/75