### PR TITLE
setup-build-env: consolidate package dependencies

### DIFF
--- a/ci/diffs/20250602-0001-selftests-bpf-Fix-bpf-selftest-build-error.patch
+++ b/ci/diffs/20250602-0001-selftests-bpf-Fix-bpf-selftest-build-error.patch
@@ -1,0 +1,59 @@
+From 4b65d5ae971430287855a89635a184c489bd02a5 Mon Sep 17 00:00:00 2001
+From: Saket Kumar Bhaskar <skb99@linux.ibm.com>
+Date: Mon, 12 May 2025 14:41:07 +0530
+Subject: [PATCH 1/3] selftests/bpf: Fix bpf selftest build error
+
+On linux-next, build for bpf selftest displays an error due to
+mismatch in the expected function signature of bpf_testmod_test_read
+and bpf_testmod_test_write.
+
+Commit 97d06802d10a ("sysfs: constify bin_attribute argument of bin_attribute::read/write()")
+changed the required type for struct bin_attribute to const struct bin_attribute.
+
+To resolve the error, update corresponding signature for the callback.
+
+Fixes: 97d06802d10a ("sysfs: constify bin_attribute argument of bin_attribute::read/write()")
+Reported-by: Venkat Rao Bagalkote <venkat88@linux.ibm.com>
+Closes: https://lore.kernel.org/all/e915da49-2b9a-4c4c-a34f-877f378129f6@linux.ibm.com/
+Tested-by: Venkat Rao Bagalkote <venkat88@linux.ibm.com>
+Signed-off-by: Saket Kumar Bhaskar <skb99@linux.ibm.com>
+Link: https://lore.kernel.org/r/20250512091108.2015615-1-skb99@linux.ibm.com
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ tools/testing/selftests/bpf/test_kmods/bpf_testmod.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tools/testing/selftests/bpf/test_kmods/bpf_testmod.c b/tools/testing/selftests/bpf/test_kmods/bpf_testmod.c
+index e6c248e3ae54..e9e918cdf31f 100644
+--- a/tools/testing/selftests/bpf/test_kmods/bpf_testmod.c
++++ b/tools/testing/selftests/bpf/test_kmods/bpf_testmod.c
+@@ -385,7 +385,7 @@ int bpf_testmod_fentry_ok;
+ 
+ noinline ssize_t
+ bpf_testmod_test_read(struct file *file, struct kobject *kobj,
+-		      struct bin_attribute *bin_attr,
++		      const struct bin_attribute *bin_attr,
+ 		      char *buf, loff_t off, size_t len)
+ {
+ 	struct bpf_testmod_test_read_ctx ctx = {
+@@ -465,7 +465,7 @@ ALLOW_ERROR_INJECTION(bpf_testmod_test_read, ERRNO);
+ 
+ noinline ssize_t
+ bpf_testmod_test_write(struct file *file, struct kobject *kobj,
+-		      struct bin_attribute *bin_attr,
++		      const struct bin_attribute *bin_attr,
+ 		      char *buf, loff_t off, size_t len)
+ {
+ 	struct bpf_testmod_test_write_ctx ctx = {
+@@ -567,7 +567,7 @@ static void testmod_unregister_uprobe(void)
+ 
+ static ssize_t
+ bpf_testmod_uprobe_write(struct file *file, struct kobject *kobj,
+-			 struct bin_attribute *bin_attr,
++			 const struct bin_attribute *bin_attr,
+ 			 char *buf, loff_t off, size_t len)
+ {
+ 	unsigned long offset = 0;
+-- 
+2.49.0
+

--- a/ci/diffs/20250602-0002-selftests-bpf-Fix-selftest-btf_tag-btf_type_tag_perc.patch
+++ b/ci/diffs/20250602-0002-selftests-bpf-Fix-selftest-btf_tag-btf_type_tag_perc.patch
@@ -1,0 +1,59 @@
+From baa39c169dd526cb0186187fc44ec462266efcc6 Mon Sep 17 00:00:00 2001
+From: Yonghong Song <yonghong.song@linux.dev>
+Date: Thu, 29 May 2025 13:11:51 -0700
+Subject: [PATCH 2/3] selftests/bpf: Fix selftest
+ btf_tag/btf_type_tag_percpu_vmlinux_helper failure
+
+Ihor Solodrai reported selftest 'btf_tag/btf_type_tag_percpu_vmlinux_helper'
+failure ([1]) during 6.16 merge window. The failure log:
+
+  ...
+  7: (15) if r0 == 0x0 goto pc+1        ; R0=ptr_css_rstat_cpu()
+  ; *(volatile int *)rstat; @ btf_type_tag_percpu.c:68
+  8: (61) r1 = *(u32 *)(r0 +0)
+  cannot access ptr member updated_children with moff 0 in struct css_rstat_cpu with off 0 size 4
+
+Two changes are needed. First, 'struct cgroup_rstat_cpu' needs to be
+replaced with 'struct css_rstat_cpu' to be consistent with new data
+structure. Second, layout of 'css_rstat_cpu' is changed compared
+to 'cgroup_rstat_cpu'. The first member becomes a pointer so
+the bpf prog needs to do 8-byte load instead of 4-byte load.
+
+  [1] https://lore.kernel.org/bpf/6f688f2e-7d26-423a-9029-d1b1ef1c938a@linux.dev/
+
+Cc: Ihor Solodrai <ihor.solodrai@linux.dev>
+Cc: JP Kobryn <inwardvessel@gmail.com>
+Signed-off-by: Yonghong Song <yonghong.song@linux.dev>
+Acked-by: JP Kobryn <inwardvessel@gmail.com>
+Link: https://lore.kernel.org/r/20250529201151.1787575-1-yonghong.song@linux.dev
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ tools/testing/selftests/bpf/progs/btf_type_tag_percpu.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tools/testing/selftests/bpf/progs/btf_type_tag_percpu.c b/tools/testing/selftests/bpf/progs/btf_type_tag_percpu.c
+index 69f81cb555ca..d93f68024cc6 100644
+--- a/tools/testing/selftests/bpf/progs/btf_type_tag_percpu.c
++++ b/tools/testing/selftests/bpf/progs/btf_type_tag_percpu.c
+@@ -57,15 +57,15 @@ int BPF_PROG(test_percpu_load, struct cgroup *cgrp, const char *path)
+ SEC("tp_btf/cgroup_mkdir")
+ int BPF_PROG(test_percpu_helper, struct cgroup *cgrp, const char *path)
+ {
+-	struct cgroup_rstat_cpu *rstat;
++	struct css_rstat_cpu *rstat;
+ 	__u32 cpu;
+ 
+ 	cpu = bpf_get_smp_processor_id();
+-	rstat = (struct cgroup_rstat_cpu *)bpf_per_cpu_ptr(
++	rstat = (struct css_rstat_cpu *)bpf_per_cpu_ptr(
+ 			cgrp->self.rstat_cpu, cpu);
+ 	if (rstat) {
+ 		/* READ_ONCE */
+-		*(volatile int *)rstat;
++		*(volatile long *)rstat;
+ 	}
+ 
+ 	return 0;
+-- 
+2.49.0
+

--- a/ci/diffs/20250602-0003-perf-Fix-the-throttle-error-of-some-clock-events.patch
+++ b/ci/diffs/20250602-0003-perf-Fix-the-throttle-error-of-some-clock-events.patch
@@ -1,0 +1,98 @@
+From df3bed9ea57603e62696a2f8aee9609d3500b7d1 Mon Sep 17 00:00:00 2001
+From: Kan Liang <kan.liang@linux.intel.com>
+Date: Wed, 28 May 2025 10:58:32 -0700
+Subject: [PATCH 3/3] perf: Fix the throttle error of some clock events
+
+The Arm CI reports RCU stall, which can be reproduced by the below perf
+command.
+  perf record -a -e cpu-clock -- sleep 2
+
+The cpu-clock and task_clock are two special SW events, which rely on
+the hrtimer. Instead of invoking the stop(), the HRTIMER_NORESTART is
+returned to stop the timer. Because the hrtimer interrupt handler cannot
+cancel itself, which causes infinite loop.
+
+There may be two ways to fix it.
+- Add a check of MAX_INTERRUPTS in the event_stop. Return immediately if
+the stop is invoked by the throttle.
+- Introduce a PMU flag to track the case. Avoid the event_stop in
+perf_event_throttle() if the flag is detected.
+
+The latter looks more generic. It may be used if there are more other
+cases that want to avoid the stop later. The latter is implemented.
+
+Reported-by: Leo Yan <leo.yan@arm.com>
+Reported-by: Aishwarya TCV <aishwarya.tcv@arm.com>
+Closes: https://lore.kernel.org/lkml/20250527161656.GJ2566836@e132581.arm.com/
+Tested-by: Leo Yan <leo.yan@arm.com>
+Signed-off-by: Kan Liang <kan.liang@linux.intel.com>
+Link: https://lore.kernel.org/r/20250528175832.2999139-1-kan.liang@linux.intel.com
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ include/linux/perf_event.h |  1 +
+ kernel/events/core.c       | 23 ++++++++++++++++++++---
+ 2 files changed, 21 insertions(+), 3 deletions(-)
+
+diff --git a/include/linux/perf_event.h b/include/linux/perf_event.h
+index 52dc7cfab0e0..97a747a97a50 100644
+--- a/include/linux/perf_event.h
++++ b/include/linux/perf_event.h
+@@ -305,6 +305,7 @@ struct perf_event_pmu_context;
+ #define PERF_PMU_CAP_EXTENDED_HW_TYPE	0x0100
+ #define PERF_PMU_CAP_AUX_PAUSE		0x0200
+ #define PERF_PMU_CAP_AUX_PREFER_LARGE	0x0400
++#define PERF_PMU_CAP_NO_THROTTLE_STOP	0x0800
+ 
+ /**
+  * pmu::scope
+diff --git a/kernel/events/core.c b/kernel/events/core.c
+index f34c99f8ce8f..abd19bb571e3 100644
+--- a/kernel/events/core.c
++++ b/kernel/events/core.c
+@@ -2656,7 +2656,22 @@ static void perf_event_unthrottle(struct perf_event *event, bool start)
+ 
+ static void perf_event_throttle(struct perf_event *event)
+ {
+-	event->pmu->stop(event, 0);
++	/*
++	 * Some PMUs, e.g., cpu-clock and task_clock, may rely on
++	 * a special mechanism (hrtimer) to manipulate counters.
++	 * The regular stop doesn't work, since the hrtimer interrupt
++	 * handler cannot cancel itself.
++	 *
++	 * The stop should be avoided for such cases. Let the
++	 * driver-specific code handle it.
++	 *
++	 * The counters will eventually be disabled in the driver-specific
++	 * code. In unthrottle, they still need to be re-enabled.
++	 * There is no handling for PERF_PMU_CAP_NO_THROTTLE_STOP in
++	 * the perf_event_unthrottle().
++	 */
++	if (!(event->pmu->capabilities & PERF_PMU_CAP_NO_THROTTLE_STOP))
++		event->pmu->stop(event, 0);
+ 	event->hw.interrupts = MAX_INTERRUPTS;
+ 	if (event == event->group_leader)
+ 		perf_log_throttle(event, 0);
+@@ -11848,7 +11863,8 @@ static int cpu_clock_event_init(struct perf_event *event)
+ static struct pmu perf_cpu_clock = {
+ 	.task_ctx_nr	= perf_sw_context,
+ 
+-	.capabilities	= PERF_PMU_CAP_NO_NMI,
++	.capabilities	= PERF_PMU_CAP_NO_NMI |
++			  PERF_PMU_CAP_NO_THROTTLE_STOP,
+ 	.dev		= PMU_NULL_DEV,
+ 
+ 	.event_init	= cpu_clock_event_init,
+@@ -11930,7 +11946,8 @@ static int task_clock_event_init(struct perf_event *event)
+ static struct pmu perf_task_clock = {
+ 	.task_ctx_nr	= perf_sw_context,
+ 
+-	.capabilities	= PERF_PMU_CAP_NO_NMI,
++	.capabilities	= PERF_PMU_CAP_NO_NMI |
++			  PERF_PMU_CAP_NO_THROTTLE_STOP,
+ 	.dev		= PMU_NULL_DEV,
+ 
+ 	.event_init	= task_clock_event_init,
+-- 
+2.49.0
+

--- a/run-vmtest/action.yml
+++ b/run-vmtest/action.yml
@@ -35,22 +35,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download vmtest
+
+    - name: Install dependencies
       shell: bash
-      run: |
-        VMTEST_URL="https://github.com/danobi/vmtest/releases/download/${{ inputs.vmtest-release }}/vmtest-$(uname -m)"
-        sudo curl -L $VMTEST_URL -o /usr/bin/vmtest
-        sudo chmod 755 /usr/bin/vmtest
-    - name: install qemu tools and selftest dependencies
-      shell: bash
-      run: |
-        source "${GITHUB_ACTION_PATH}/../helpers.sh"
-        foldable start install_qemu "Installing QEMU tools"
-        # need gawk to support `--field-separator`
-        sudo apt-get update && sudo apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent \
-          ethtool keyutils iptables libpcap-dev \
-          gawk
-        foldable end install_qemu
+      env:
+        VMTEST_RELEASE: ${{ inputs.vmtest-release }}
+      run: ${GITHUB_ACTION_PATH}/install-dependencies.sh
+
     - name: Configure KVM group perms
       shell: bash
       run: |
@@ -64,6 +55,7 @@ runs:
           sudo udevadm trigger --name-match=kvm
         fi
         foldable end config_kvm
+
     - name: Run vmtest
       shell: bash
       env:

--- a/run-vmtest/install-dependencies.sh
+++ b/run-vmtest/install-dependencies.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VMTEST_RELEASE=${VMTEST_RELEASE:-v0.15.0}
+VMTEST_URL="https://github.com/danobi/vmtest/releases/download/${VMTEST_RELEASE}/vmtest-$(uname -m)"
+sudo curl -L $VMTEST_URL -o /usr/bin/vmtest
+sudo chmod 755 /usr/bin/vmtest
+
+sudo apt-get update -y
+sudo -E apt-get install --no-install-recommends -y \
+     cpu-checker ethtool gawk iproute2 iptables iputils-ping keyutils libpcap-dev
+sudo -E apt-get install --no-install-recommends -y \
+     qemu-guest-agent qemu-kvm qemu-system-arm qemu-system-s390x qemu-system-x86 qemu-utils

--- a/setup-build-env/install_clang.sh
+++ b/setup-build-env/install_clang.sh
@@ -6,6 +6,10 @@ source "${THISDIR}"/../helpers.sh
 
 foldable start install_clang "Install LLVM ${LLVM_VERSION}"
 
+sudo apt-get update -y
+sudo -E apt-get install --no-install-recommends -y \
+     gnupg lsb-release software-properties-common wget
+
 curl -O https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
 sudo ./llvm.sh ${LLVM_VERSION}

--- a/setup-build-env/install_packages.sh
+++ b/setup-build-env/install_packages.sh
@@ -12,11 +12,20 @@ foldable start install_packages
 
 sudo apt-get update -y
 
-sudo -E apt-get install --no-install-recommends -y                    \
-     bc binutils-dev bison build-essential cmake curl elfutils flex   \
-     libcap-dev libdw-dev libelf-dev libguestfs-tools libpcap-dev     \
-     libssl-dev libzstd-dev ncurses-dev pkg-config python3-docutils   \
-     qemu-kvm qemu-utils rsync texinfo tzdata xz-utils zstd
+sudo -E apt-get install --no-install-recommends -y                     \
+     bc bison build-essential cmake cpu-checker curl dumb-init         \
+     elfutils ethtool ethtool flex gawk git iproute2 iptables          \
+     iputils-ping jq keyutils libguestfs-tools pkg-config              \
+     python3-docutils python3-minimal rsync software-properties-common \
+     sudo texinfo tree tzdata wget xz-utils zstd
+
+sudo -E apt-get install --no-install-recommends -y            \
+     binutils-dev libcap-dev libdw-dev libelf-dev libpcap-dev \
+     libssl-dev libzstd-dev ncurses-dev
+
+sudo -E apt-get install --no-install-recommends -y               \
+     qemu-guest-agent qemu-kvm qemu-system-arm qemu-system-s390x \
+     qemu-system-x86 qemu-utils
 
 sudo apt-get install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 10


### PR DESCRIPTION
BPF CI self-hosted runner docker images moved to using setup-build-env scripts at build time [1]. Consolidate the list of packages to install in the action script.