### PR TITLE
build-scx-scheds: introduce SCX_REVISION variable

### DIFF
--- a/build-scx-scheds/build-scheds.sh
+++ b/build-scx-scheds/build-scheds.sh
@@ -4,10 +4,14 @@ set -euo pipefail
 
 export LLVM_VERSION=${LLVM_VERSION:-20}
 export SCX_ROOT=${SCX_ROOT:-}
+export SCX_REVISION=${SCX_REVISION:-main}
 
 if [[ -z "$SCX_ROOT" ]]; then
     export SCX_ROOT=$(mktemp -d scx.XXXX)
-    git clone --depth=1 --branch=main https://github.com/sched-ext/scx.git $SCX_ROOT
+    git clone --branch=main https://github.com/sched-ext/scx.git $SCX_ROOT
+    pushd $SCX_ROOT
+    git reset --hard $SCX_REVISION
+    popd
 fi
 
 pushd $SCX_ROOT
@@ -17,3 +21,4 @@ meson compile -C build
 rm -rf $OUTPUT_DIR
 mv build $OUTPUT_DIR
 popd
+


### PR DESCRIPTION
Allow to specify sched-ext revision in build-scx-scheds action.