### PR TITLE
build-scx-scheds: install recent meson with pipx

### DIFF
--- a/build-scx-scheds/install-dependencies.sh
+++ b/build-scx-scheds/install-dependencies.sh
@@ -4,12 +4,28 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 export LLVM_VERSION=${LLVM_VERSION:-20}
+export PIPX_VERSION=${PIPX_VERSION:-1.7.1}
 
 # Assume Ubuntu/Debian
 sudo -E apt-get -y update
 
+# Download and install pipx
+sudo -E apt-get --no-install-recommends -y install wget python3 python3-pip python3-venv
+wget "https://github.com/pypa/pipx/releases/download/${PIPX_VERSION}/pipx.pyz"
+mv pipx.pyz /usr/bin/pipx && chmod +x /usr/bin/pipx
+
+# pipx ensurepath is not doing what we need
+# install pipx apps to /usr/local/bin manually
+pipx install meson
+pipx install ninja
+sudo cp -a ~/.local/bin/meson /usr/local/bin
+sudo cp -a ~/.local/bin/ninja /usr/local/bin
+
+meson --version
+ninja --version
+
 # Install LLVM
-sudo -E apt-get -y install lsb-release wget software-properties-common gnupg
+sudo -E apt-get --no-install-recommends -y install lsb-release wget software-properties-common gnupg
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
 sudo -E ./llvm.sh ${LLVM_VERSION}
@@ -25,6 +41,6 @@ sudo update-alternatives --install \
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-sudo -E apt-get -y install \
-    build-essential libssl-dev libelf-dev meson cmake pkg-config jq \
+sudo -E apt-get --no-install-recommends -y install \
+    build-essential libssl-dev libelf-dev cmake pkg-config jq \
     protobuf-compiler libseccomp-dev


### PR DESCRIPTION
meson installed via apt on Ubuntu 24 turns out to be quite old (1.3.2 vs latest 1.8.2). This caused scx build failures [1].

pipx [2] is a recommended way to install such python apps.

Update build-scx-scheds/install-dependencies.sh script to handle the installations properly.

[1] https://github.com/kernel-patches/bpf/actions/runs/15850271078/job/44682123061
[2] https://github.com/pypa/pipx