### PR TITLE
Add xxd to the base CI debian image

### DIFF
--- a/rootfs/mkrootfs_debian.sh
+++ b/rootfs/mkrootfs_debian.sh
@@ -154,6 +154,7 @@ packages=(
 	openssl
 	strace
 	zlib1g
+ 	xxd
 )
 packages=$(IFS=, && echo "${packages[*]}")
 


### PR DESCRIPTION
xxd is used to generate a C header from a verification certificate (DER encoded) which is used to test BPF signing infrastructure in selftests.