### PR TITLE
get-linux-source: use an env var for the ACTION_PATH

### DIFF
--- a/get-linux-source/action.yml
+++ b/get-linux-source/action.yml
@@ -17,8 +17,10 @@ runs:
   steps:
     - name: Get bpf-next source
       shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        KERNEL_ORIGIN: ${{ inputs.repo }}
+        KERNEL_BRANCH: ${{ inputs.rev }}
+        REPO_PATH: ${{ inputs.dest }}
       run: |
-        export KERNEL_ORIGIN='${{ inputs.repo }}'
-        export KERNEL_BRANCH='${{ inputs.rev }}'
-        export REPO_PATH='${{ inputs.dest }}'
-        ${{ github.action_path }}/checkout_latest_kernel.sh
+        ${ACTION_PATH}/checkout_latest_kernel.sh


### PR DESCRIPTION
Move ${{ github.action_path }} from inline run: usage to env: section as ACTION_PATH. The runner's ContainerStepHost translates env var paths for container jobs (host path → container path), but does not translate paths embedded in run: script content. This fixes composite actions when called from a workflow with a container: directive.

Also move inline export vars (KERNEL_ORIGIN, KERNEL_BRANCH, REPO_PATH) to env: for consistency with other actions in this repo.

[1] https://github.com/actions/runner/blob/main/src/Runner.Worker/Handlers/StepHost.cs#L108

Assisted-by: Claude:claude-opus-4-6