### PR TITLE
ci: pass all inputs via env vars in composite actions

### DIFF
--- a/build-selftests/action.yml
+++ b/build-selftests/action.yml
@@ -21,7 +21,10 @@ runs:
     - name: build selftests
       shell: bash
       env:
+        ARCH: ${{ inputs.arch }}
+        KERNEL_ROOT: ${{ inputs.kernel-root }}
         LLVM_VERSION: ${{ inputs.llvm-version }}
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
-        ${GITHUB_ACTION_PATH}/build_selftests.sh "${{ inputs.arch }}" "${{ inputs.toolchain }}" "${{ inputs.kernel-root }}"
+        ${GITHUB_ACTION_PATH}/build_selftests.sh "${ARCH}" "${TOOLCHAIN}" "${KERNEL_ROOT}"
 

--- a/download-vmlinux/action.yml
+++ b/download-vmlinux/action.yml
@@ -13,6 +13,8 @@ runs:
     - name: Download prebuilt vmlinux
       shell: bash
       env:
+        ACTION_PATH: ${{ github.action_path }}
         ARCH: ${{ inputs.arch }}
+        KERNEL: ${{ inputs.kernel }}
       run: |
-        ${{ github.action_path }}/run.sh -k '${{ inputs.kernel }}'
+        ${ACTION_PATH}/run.sh -k "${KERNEL}"

--- a/patch-kernel/action.yml
+++ b/patch-kernel/action.yml
@@ -14,4 +14,7 @@ runs:
   steps:
     - name: apply temporary patches
       shell: bash
-      run: cd ${{ inputs.repo-root }} && ${GITHUB_ACTION_PATH}/patch_kernel.sh "${{ inputs.patches-root }}"
+      env:
+        REPO_ROOT: ${{ inputs.repo-root }}
+        PATCHES_ROOT: ${{ inputs.patches-root }}
+      run: cd ${REPO_ROOT} && ${GITHUB_ACTION_PATH}/patch_kernel.sh "${PATCHES_ROOT}"


### PR DESCRIPTION
In container jobs, ${{ github.action_path }} and ${{ inputs.* }} expressions in run: blocks evaluate to host paths that don't exist inside the container. The runner's ContainerStepHost translates env var values but not run: script content.

Move all inline expressions to env: sections for consistency and container compatibility:
- get-linux-source: ACTION_PATH, KERNEL_ORIGIN, KERNEL_BRANCH, REPO_PATH
- download-vmlinux: ACTION_PATH, KERNEL
- patch-kernel: REPO_ROOT, PATCHES_ROOT
- build-selftests: ARCH, KERNEL_ROOT, TOOLCHAIN

Assisted-by: Claude:claude-opus-4-6