### PR TITLE
run-vmtest: set no5lvl for the VMs

### DIFF
--- a/run-vmtest/run.sh
+++ b/run-vmtest/run.sh
@@ -96,7 +96,7 @@ cat > $VMTEST_TOML <<EOF
 [[target]]
 name = "run-vmtest"
 kernel = "${VMLINUZ}"
-kernel_args = "panic=-1 sysctl.vm.panic_on_oom=1 hardlockup_all_cpu_backtrace=1 softlockup_all_cpu_backtrace=1 kasan_multi_shot"
+kernel_args = "panic=-1 sysctl.vm.panic_on_oom=1 hardlockup_all_cpu_backtrace=1 softlockup_all_cpu_backtrace=1 kasan_multi_shot no5lvl"
 command = """\
 ${GITHUB_ACTION_PATH}/vmtest-init.sh && \
 cd ${GITHUB_WORKSPACE} && \


### PR DESCRIPTION
There are flaky boot crashes on BPF CI:
* https://github.com/kernel-patches/bpf/actions/runs/27271262414/job/80542509369
* https://github.com/kernel-patches/bpf/actions/runs/27260143782/job/80505353689

They seem to disappear with 5-level paging turned off.

Add no5lvl to the boot params to mitigate.