### PR TITLE
build-cilium: Match LLVM version of Cilium

### DIFF
--- a/build-cilium/install-dependencies.sh
+++ b/build-cilium/install-dependencies.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-export LLVM_VERSION=${LLVM_VERSION:-21}
+export LLVM_VERSION=${LLVM_VERSION:-19}
 export LIBBPF_REVISION=${LIBBPF_REVISION:-master}
 export BPFTOOL_REVISION=${BPFTOOL_REVISION:-main}
 


### PR DESCRIPTION
Cilium is currently built with LLVM 19.1.7 [1, 2]. Let's build the test programs for the BPF CI with the same LLVM version to avoid any surprises and best represent what Cilium runs with.

1: https://github.com/cilium/image-tools/blob/7b2a83e60222ae3187aac2e93b7da32e6401fad8/images/llvm/Dockerfile#L12
2: https://github.com/cilium/cilium/blob/fb82afd2a145de284c05ca11cd8e40694850a90f/images/runtime/Dockerfile#L9

cc @puranjaymohan @theihor 