### PR TITLE
build-bpf-gcc: add gcc-version input to select the GCC major version

### DIFF
--- a/build-bpf-gcc/action.yml
+++ b/build-bpf-gcc/action.yml
@@ -4,6 +4,10 @@ inputs:
   install-dir:
     description: "Path to the GCC installation directory"
     required: true
+  gcc-version:
+    description: "Major GCC version to build (e.g. 15, 16)"
+    required: false
+    default: "15"
 
 runs:
   using: "composite"
@@ -12,6 +16,8 @@ runs:
     - name: Determine latest snapshots
       id: latest-snapshots
       shell: bash
+      env:
+        GCC_VERSION: ${{ inputs.gcc-version }}
       run: ${GITHUB_ACTION_PATH}/latest-snapshots.sh
 
     - uses: actions/cache@v4

--- a/build-bpf-gcc/latest-snapshots.sh
+++ b/build-bpf-gcc/latest-snapshots.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# Major GCC version to build; defaults to 15 for backward compatibility.
+GCC_VERSION="${GCC_VERSION:-15}"
+
 BINUTILS_TARBALL=$(wget https://snapshots.sourceware.org/binutils/trunk/latest/src/sha512.sum -O - -o /dev/null | awk '{print $2}')
-GCC_TARBALL=$(wget https://gcc.gnu.org/pub/gcc/snapshots/LATEST-15 -O - -o /dev/null | grep -E 'gcc-15-[0-9]+.tar.xz' | sed -e 's/.*\(gcc-15-[^<]*\).*/\1/')
+GCC_TARBALL=$(wget https://gcc.gnu.org/pub/gcc/snapshots/LATEST-${GCC_VERSION} -O - -o /dev/null | grep -E "gcc-${GCC_VERSION}-[0-9]+.tar.xz" | sed -e "s/.*\(gcc-${GCC_VERSION}-[^<]*\).*/\1/")
 
 BINUTILS_URL="https://snapshots.sourceware.org/binutils/trunk/latest/src/$BINUTILS_TARBALL"
-GCC_URL="https://gcc.gnu.org/pub/gcc/snapshots/LATEST-15/$GCC_TARBALL"
+GCC_URL="https://gcc.gnu.org/pub/gcc/snapshots/LATEST-${GCC_VERSION}/$GCC_TARBALL"
 
 BINUTILS_BASENAME=$(basename $BINUTILS_TARBALL .tar.xz)
 GCC_BASENAME=$(basename $GCC_TARBALL .tar.xz)


### PR DESCRIPTION
The GCC major version was hardcoded to 15 in latest-snapshots.sh. Add a 'gcc-version' action input (default "15", so existing callers are unchanged) that is passed through as $GCC_VERSION and used to pick the LATEST-<version> snapshot directory and tarball. This lets callers (e.g. theihor/gcc-bpf) build GCC 16 for BPF CI toolchain experiments without forking the action.