### PR TITLE
normalize_bpf_test_names: don't drop tests that share a name prefix

### DIFF
--- a/run-vmtest/normalize_bpf_test_names.py
+++ b/run-vmtest/normalize_bpf_test_names.py
@@ -45,7 +45,10 @@ def next_test(lines: list[str]):
     prev = lines[0]
 
     def is_subtest(line: str) -> bool:
-        return ('/' in line) and ('/' not in prev) and line.startswith(prev)
+        # Compare against "prev/" rather than "prev": without the separator
+        # "a_test" also swallows "a_test_two/subtest", which is a subtest of a
+        # different test that happens to share a prefix.
+        return ('/' not in prev) and line.startswith(prev + '/')
 
     yield lines[0]
     for line in lines[1:]:

--- a/run-vmtest/tests/normalize_bpf_test_names/expected-output.txt
+++ b/run-vmtest/tests/normalize_bpf_test_names/expected-output.txt
@@ -10,3 +10,5 @@ test4_blah
 test5
 test6
 test7/subtest123
+test8
+test8_peek/subtest1

--- a/run-vmtest/tests/normalize_bpf_test_names/input.txt
+++ b/run-vmtest/tests/normalize_bpf_test_names/input.txt
@@ -18,3 +18,5 @@ test5                                                   # should consume test5/s
    ## some blank lines, should be removed
       
 
+test8
+test8_peek/subtest1                                     # must be kept: test8_peek is a different test, not a subtest of test8


### PR DESCRIPTION
Subtest deduplication compares the subtest against the bare test name with a plain startswith(), so any test whose name begins with the name of another denied test loses its subtest entries. With

  linked_list
  linked_list_peek/test_back_spinlock_false
  linked_list_peek/test_front_spinlock_false

both linked_list_peek entries are dropped, because they start with "linked_list". They are subtests of linked_list_peek, which is an unrelated test, so they end up running after all. In BPF CI this silently un-denied two GCC BPF tests and failed the job.

Compare against "prev/" instead, so only a real subtest is consumed. The '/' in the line no longer needs checking separately: a line starting with "prev/" contains one by construction.

Extend the test with a pair that reproduces this. It has to be a name that sorts immediately after the bare one, otherwise the running "prev" has already moved on to another entry and the comparison never happens, which is why the existing test4 / test4_blah pair does not catch it.

Link: https://github.com/kernel-patches/vmtest/actions/runs/31203330693/job/92951247492