### PR TITLE
normalize traffic monitor log paths in a final always() step

### DIFF
--- a/run-vmtest/action.yml
+++ b/run-vmtest/action.yml
@@ -69,3 +69,12 @@ runs:
       run: |
         ${GITHUB_ACTION_PATH}/run.sh
 
+    # Callers upload this directory with if: always(), and the upload rejects
+    # the characters this renames, so it has to happen even when the step
+    # above fails.
+    - name: Normalize traffic monitor log paths
+      if: always()
+      shell: bash
+      run: |
+        ${GITHUB_ACTION_PATH}/normalize-paths-for-github.sh /tmp/tmon_pcap
+

--- a/run-vmtest/run.sh
+++ b/run-vmtest/run.sh
@@ -115,10 +115,6 @@ foldable end vmtest_toml
 vmtest -c $VMTEST_TOML
 rm -f $VMTEST_TOML
 
-# fixup traffic montioring log paths if present
-PCAP_DIR=/tmp/tmon_pcap
-${GITHUB_ACTION_PATH}/normalize-paths-for-github.sh "$PCAP_DIR"
-
 foldable end vmtest
 
 foldable start collect_status "Collecting exit status"


### PR DESCRIPTION
run.sh renames the traffic monitor logs that actions/upload-artifact refuses, but it does so right after vmtest returns, so nothing renames them when the vmtest step does not get that far. Callers upload the directory with if: always(), so the upload still runs and fails on the leftover names:

  Error: The path for one of the files in artifact is not valid:
  /packets-125-15-net_timestamping__INET4:_bpf_timestamping-net_timestamping_ns.log.
  Contains the following character:  Colon :

Move the call out of run.sh into a last step of the action, guarded by if: always(), so it runs whatever happened to the step before it. The script already returns early when the directory does not exist, which is the case for every test that does not enable the traffic monitor.

This was initially proposed as [vmtest](https://github.com/kernel-patches/vmtest/pull/504) but that does copy/paste. 